### PR TITLE
Ensure websocket connect is not blocking

### DIFF
--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -87,7 +87,8 @@ func New(logger *logger.Logger,
 		subscribed:          false,
 	}
 
-	ws.Connect()
+	// Connect to the websocket in a go routine incase it takes a long time
+	go ws.Connect()
 
 	// Listener for any incoming messages
 	ws.tmb.Go(func() error {


### PR DESCRIPTION
## Description of the change

Ensures that the websocket is connected to in the background and is not blocking

Also separates the ready code to its own handler instead of root callback

## Relevant release note information

Release Notes: Ensure websocket connection happens in go routine + separate ready to own handler 

## Related JIRA tickets

Relates to JIRA: CWC-1360

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: