### PR TITLE
Add catch for 401 unauth response

### DIFF
--- a/bctl/agent/agent.go
+++ b/bctl/agent/agent.go
@@ -92,7 +92,7 @@ func startControlChannel(logger *logger.Logger, agentVersion string) error {
 	// create a websocket
 	wsId := uuid.New().String()
 	wsLogger := logger.GetWebsocketLogger(wsId) // TODO: replace with actual connectionId
-	websocket, err := websocket.New(wsLogger, wsId, serviceUrl, controlHubEndpoint, params, headers, ccTargetSelectHandler, true, true)
+	websocket, err := websocket.New(wsLogger, wsId, serviceUrl, controlHubEndpoint, params, headers, ccTargetSelectHandler, true, true, "")
 	if err != nil {
 		return err
 	}

--- a/bctl/agent/controlchannel/controlchannel.go
+++ b/bctl/agent/controlchannel/controlchannel.go
@@ -125,7 +125,7 @@ func (c *ControlChannel) openWebsocket(message OpenWebsocketMessage) error {
 	params["daemon_connection_id"] = message.ConnectionId
 	params["token"] = message.Token
 
-	if ws, err := websocket.New(subLogger, message.ConnectionId, c.serviceUrl, c.hubEndpoint, params, headers, c.dcTargetSelectHandler, false, false); err != nil {
+	if ws, err := websocket.New(subLogger, message.ConnectionId, c.serviceUrl, c.hubEndpoint, params, headers, c.dcTargetSelectHandler, false, false, ""); err != nil {
 		return fmt.Errorf("could not create new websocket: %s", err)
 	} else {
 		// add the websocket to our connections dictionary

--- a/bctl/daemon/httpserver/httpserver.go
+++ b/bctl/daemon/httpserver/httpserver.go
@@ -144,7 +144,7 @@ func (k *HTTPServer) statusCallback(w http.ResponseWriter, r *http.Request) {
 // for creating new websockets
 func (h *HTTPServer) newWebsocket(wsId string) error {
 	subLogger := h.logger.GetWebsocketLogger(wsId)
-	if wsClient, err := websocket.New(subLogger, wsId, h.serviceUrl, h.hubEndpoint, h.params, h.headers, h.targetSelectHandler, autoReconnect, getChallenge); err != nil {
+	if wsClient, err := websocket.New(subLogger, wsId, h.serviceUrl, h.hubEndpoint, h.params, h.headers, h.targetSelectHandler, autoReconnect, getChallenge, h.refreshTokenCommand); err != nil {
 		return err
 	} else {
 		h.websocket = wsClient

--- a/bctl/daemon/keysplitting/keysplitting.go
+++ b/bctl/daemon/keysplitting/keysplitting.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"strings"
 	"time"
 
 	bzcrt "bastionzero.com/bctl/v1/bzerolib/keysplitting/bzcert"
@@ -184,12 +182,8 @@ func (k *Keysplitting) BuildSyn(action string, payload []byte) (ksmsg.Keysplitti
 
 func (k *Keysplitting) buildBZCert() (bzcrt.BZCert, error) {
 	// update the id token by calling the passed in zli command
-	if splits := strings.Split(k.refreshTokenCommand, " "); len(splits) >= 2 {
-		if out, err := exec.Command(splits[0], splits[1:]...).CombinedOutput(); err != nil {
-			return bzcrt.BZCert{}, fmt.Errorf("%s while executing zli refresh token command: %s", err, string(out))
-		}
-	} else {
-		return bzcrt.BZCert{}, fmt.Errorf("not enough arguments to refresh token zli command: %v", len(splits))
+	if err := util.RunRefreshAuthCommand(k.refreshTokenCommand); err != nil {
+		return bzcrt.BZCert{}, err
 	}
 
 	if configFile, err := os.Open(k.configPath); err != nil {

--- a/bzerolib/bzhttp/bzhttp.go
+++ b/bzerolib/bzhttp/bzhttp.go
@@ -115,7 +115,7 @@ func (b *bzhttp) post() (*http.Response, error) {
 		}
 
 		// If the status code is unauthorized, do not attempt to retry
-		if response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusUnauthorized {
+		if response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusUnauthorized || response.StatusCode == http.StatusUnsupportedMediaType {
 			ticker.Stop()
 			return response, fmt.Errorf("received response code: %d, not retrying", response.StatusCode)
 		}

--- a/bzerolib/bzhttp/bzhttp.go
+++ b/bzerolib/bzhttp/bzhttp.go
@@ -115,7 +115,7 @@ func (b *bzhttp) post() (*http.Response, error) {
 		}
 
 		// If the status code is unauthorized, do not attempt to retry
-		if response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusNotFound {
+		if response.StatusCode == http.StatusInternalServerError || response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusUnauthorized {
 			ticker.Stop()
 			return response, fmt.Errorf("received response code: %d, not retrying", response.StatusCode)
 		}

--- a/bzerolib/keysplitting/util/util.go
+++ b/bzerolib/keysplitting/util/util.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"os/exec"
 	"strings"
 
 	"golang.org/x/crypto/sha3"
@@ -42,4 +44,15 @@ func Nonce() string {
 	b := make([]byte, 32) // 32-length byte array, to make it same length as hash pointer
 	rand.Read(b)          // populate with random bytes
 	return base64.StdEncoding.EncodeToString(b)
+}
+
+func RunRefreshAuthCommand(refreshCommand string) error {
+	if splits := strings.Split(refreshCommand, " "); len(splits) >= 2 {
+		if out, err := exec.Command(splits[0], splits[1:]...).CombinedOutput(); err != nil {
+			fmt.Errorf("%s while executing zli refresh token command: %s", err, string(out))
+		}
+	} else {
+		fmt.Errorf("not enough arguments to refresh token zli command: %v", len(splits))
+	}
+	return nil
 }


### PR DESCRIPTION
## Description of the change

Ensures that we do not keep trying to make connections for 401 unauthorized response.

This PR also adds a catch to ensure that if we ever pass an invalid json from the daemon we do not attempt to keep trying to make that connection. 

Tested with latest code and all is working as expected: 
![2021-12-22 at 7 36 PM](https://user-images.githubusercontent.com/28202162/147105124-1ff02b20-1a30-4b93-a842-ec22f225f42d.jpg)



## Relevant release note information

Release Notes: Adds catch for 401 Unauthorized response and invalid json payload

## Related JIRA tickets

Relates to JIRA: CWC-1371

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: