### PR TITLE
Add awsregion to passed param

### DIFF
--- a/bctl/agent/agent.go
+++ b/bctl/agent/agent.go
@@ -6,8 +6,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -24,6 +27,7 @@ import (
 
 const (
 	prodServiceUrl = "https://cloud.bastionzero.com/"
+	whereEndpoint  = "status/where"
 )
 
 var (
@@ -224,6 +228,7 @@ type RegistrationRequest struct {
 	TargetHostName  string `json:"targetHostName"`
 	TargetType      string `json:"agentType"`
 	TargetId        string `json:"targetId"`
+	AwsRegion       string `json:"awsRegion"`
 }
 
 type RegistrationResponse struct {
@@ -367,6 +372,27 @@ func getRegistrationResponse(logger *logger.Logger, publicKey string) (Registrat
 		return regResponse, fmt.Errorf("could not resolve hostname")
 	}
 
+	// Get our region by pinging out connection-service
+	connectionServiceUrl := getConnectionServiceUrlFromServiceUrl(serviceUrl)
+	whereEndpoint, whereErr := utils.JoinUrls(connectionServiceUrl, whereEndpoint)
+	if whereErr != nil {
+		return regResponse, whereErr
+	}
+	whereEndpointWScheme, whereErrWScheme := utils.JoinUrls("https://", whereEndpoint)
+	if whereErrWScheme != nil {
+		return regResponse, whereErrWScheme
+	}
+	regionResponse, errRegion := bzhttp.Get(logger, whereEndpointWScheme, map[string]string{}, map[string]string{})
+	if errRegion != nil {
+		return regResponse, errRegion
+	}
+
+	regionBodyBytes, regionReadError := io.ReadAll(regionResponse.Body)
+	if regionReadError != nil {
+		log.Fatal(err)
+	}
+	region := string(regionBodyBytes)
+
 	// Create our request
 	req := RegistrationRequest{
 		PublicKey:       publicKey,
@@ -378,6 +404,7 @@ func getRegistrationResponse(logger *logger.Logger, publicKey string) (Registrat
 		TargetHostName:  hostname,
 		TargetType:      agentType,
 		TargetId:        activationToken, // The activation token is the new targetId
+		AwsRegion:       region,
 	}
 
 	// Build the endpoint we want to hit
@@ -413,4 +440,12 @@ func getRegistrationResponse(logger *logger.Logger, publicKey string) (Registrat
 
 		return regResponse, nil
 	}
+}
+
+func getConnectionServiceUrlFromServiceUrl(serviceUrl string) string {
+	toReplaceRegex := regexp.MustCompile(`([a-z]*).bastionzero.com`)
+	groupMaches := toReplaceRegex.FindStringSubmatch(serviceUrl)
+	prefix := groupMaches[1] // Extract cloud from cloud.bastionzero.com
+	connectUrl := fmt.Sprintf("%s-connection-service", prefix)
+	return strings.Replace(serviceUrl, prefix, connectUrl, -1)
 }

--- a/bctl/agent/agent.go
+++ b/bctl/agent/agent.go
@@ -90,11 +90,10 @@ func startControlChannel(logger *logger.Logger, agentVersion string) error {
 
 	// Make and add our params
 	params := map[string]string{
-		"public_key":  config.Data.PublicKey,
-		"version":     agentVersion,
-		"target_id":   config.Data.TargetId,
-		"target_name": targetName,
-		"agent_type":  agentType,
+		"public_key": config.Data.PublicKey,
+		"version":    agentVersion,
+		"target_id":  config.Data.TargetId,
+		"agent_type": agentType,
 	}
 
 	// create a websocket
@@ -226,7 +225,6 @@ type RegistrationRequest struct {
 	EnvironmentName string `json:"environmentName"`
 	TargetName      string `json:"targetName"`
 	TargetHostName  string `json:"targetHostName"`
-	TargetType      string `json:"agentType"`
 	TargetId        string `json:"targetId"`
 	AwsRegion       string `json:"awsRegion"`
 }
@@ -402,7 +400,6 @@ func getRegistrationResponse(logger *logger.Logger, publicKey string) (Registrat
 		EnvironmentName: environmentName,
 		TargetName:      targetName,
 		TargetHostName:  hostname,
-		TargetType:      agentType,
 		TargetId:        activationToken, // The activation token is the new targetId
 		AwsRegion:       region,
 	}


### PR DESCRIPTION
## Description of the change

Adds the relevant AWS Region to the register agent request. Tested and is working 
![2022-01-18 at 11 10 AM](https://user-images.githubusercontent.com/28202162/149974690-f8170d57-0b04-4853-bc03-ce09aca936e2.png)

Not sure the best place to put it, but this is at least the code for it, definitely want to revisit the regex used, we could pass it in as a var, but then when the user starts they have to type in two `serviceUrl` and `connectionServiceUrl`? seems ugly, not sure what the best thing to do is, but maybe it can wait 


## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: