### PR TITLE
Adds interactive shell plugin and tests

### DIFF
--- a/bctl/agent/config/config.go
+++ b/bctl/agent/config/config.go
@@ -1,0 +1,27 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package config
+
+const (
+
+	// Buffer capacity of 100000 items with each buffer item of 1024 bytes leads to max usage of 100MB (100000 * 1024 bytes = 100MB) of instance memory.
+	// When changing StreamDataPayloadSize, make corresponding change to buffer capacity to ensure no more than 100MB of instance memory is used.
+	StreamDataPayloadSize         = 1024
+	OutgoingMessageBufferCapacity = 100 * 1000
+	IncomingMessageBufferCapacity = 100 * 1000
+	ShellStdOutBuffCapacity       = 10 * 1000
+
+	// ExitCodes
+	ErrorExitCode = 1
+)

--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -26,9 +26,10 @@ import (
 type PluginName string
 
 const (
-	Kube PluginName = "kube"
-	Db   PluginName = "db"
-	Web  PluginName = "web"
+	Kube  PluginName = "kube"
+	Db    PluginName = "db"
+	Web   PluginName = "web"
+	Shell PluginName = "shell"
 )
 
 type DataChannel struct {

--- a/bctl/agent/plugin/shell/execcmd/execcmd.go
+++ b/bctl/agent/plugin/shell/execcmd/execcmd.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package execcmd wraps up the os.Process interface.
+package execcmd
+
+import (
+	"os/exec"
+)
+
+//IExecCmd is an abstracted interface of os.Process
+type IExecCmd interface {
+	Pid() int
+	//kill the attached child process
+	Kill() error
+	//wait for the child to finish
+	Wait() error
+}
+
+//implementation of IExecCmd with os.Process embed
+type ExecCmd struct {
+	Cmd *exec.Cmd
+}
+
+// NewExecCmd returns a new instance of the ExecCmd
+func NewExecCmd(command *exec.Cmd) *ExecCmd {
+	return &ExecCmd{Cmd: command}
+}
+
+// Pid returns the process id.
+func (p *ExecCmd) Pid() int {
+	return p.Cmd.Process.Pid
+}
+
+// Kill causes the Process to exit immediately. Kill does not wait until
+// the Process has actually exited. This only kills the Process itself,
+// not any other processes it may have started.
+func (p *ExecCmd) Kill() error {
+	if p.Cmd != nil && p.Cmd.Process != nil {
+		return p.Cmd.Process.Kill()
+	}
+	return nil
+}
+
+// Wait releases any resources associated with the Cmd.
+func (p *ExecCmd) Wait() error {
+	if p.Cmd != nil {
+		return p.Cmd.Wait()
+	}
+	return nil
+}

--- a/bctl/agent/plugin/shell/shell.go
+++ b/bctl/agent/plugin/shell/shell.go
@@ -1,0 +1,311 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This code has been modified from the code covered by the Apache License 2.0.
+// Modifications Copyright (C) 2022 BastionZero Inc.  The BastionZero Agent
+// is licensed under the Apache 2.0 License.
+
+package shell
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"bastionzero.com/bctl/v1/bctl/agent/config"
+	"bastionzero.com/bctl/v1/bctl/agent/datachannel"
+	"bastionzero.com/bctl/v1/bctl/agent/plugin/shell/execcmd"
+
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
+	"gopkg.in/tomb.v2"
+)
+
+// ShellPlugin - Allows launching an interactive shell on the host which the agent is running on.
+//
+//
+//   New - Configures the shell including setting the RunAsUser but doesn't launch it
+//   Receive - receives MRZAP actions and dispatches them to the correct methods
+//
+//		Current shell actions
+// 			ShellOpen   KeysplittingAction = "shell/open"
+// 			ShellClose  KeysplittingAction = "shell/close"
+// 			ShellInput  KeysplittingAction = "shell/input"
+// 			ShellResize KeysplittingAction = "shell/resize"
+// 			FudDownload KeysplittingAction = "fud/download" -- Not currently implemented
+// 			FudUpload   KeysplittingAction = "fud/upload" -- Not currently implemented
+// 		 		- sourced from https://github.com/bastionzero/bzero-ssm-agent/blob/bzero-dev/agent/keysplitting/contracts/model.go#L106
+//
+//  User interaction works as follows:
+//  	user keypresses --> DataChannel --> plugin.Receive(shell/input) --> p.ShellInput(..) --> pty.stdIn
+//  	user terminal <-- streamOutputChan <-- p.writePump(...) <-- pty.stdOut <-- terminal output
+//
+// We follow a pattern of wrapping the pty functions in ShellPlugin
+// 		plugin.open --> pty.Start() Creates New pty
+// 		plugin.setSize --> pty.SetSize() ReSizes the pty
+//  	plugin.shellInput --> pty.stdIn
+//		plugin.close --> pty.ptyfile.close()
+//
+//		This should allow use to mock at the level of the ShellPlugin since none of the pty details are exposed
+
+type ShellPlugin struct {
+	tmb              *tomb.Tomb // datachannel's tomb
+	logger           *logger.Logger
+	name             string
+	stdin            *os.File
+	stdout           *os.File
+	execCmd          execcmd.IExecCmd
+	streamOutputChan chan smsg.StreamMessage
+	shellStarted     bool
+	runAsUser        string
+}
+
+// New returns a new instance of the Shell Plugin
+func New(parentTmb *tomb.Tomb,
+	logger *logger.Logger,
+	ch chan smsg.StreamMessage,
+	payload []byte) (*ShellPlugin, error) {
+
+	// Unmarshal the Syn payload
+	var configPayload bzshell.ShellConfigParams
+	if err := json.Unmarshal(payload, &configPayload); err != nil {
+		return &ShellPlugin{}, fmt.Errorf("malformed Shell plugin SYN payload %v", string(payload))
+	}
+
+	var plugin = ShellPlugin{
+		runAsUser:        configPayload.RunAsUser,
+		shellStarted:     false,
+		logger:           logger,
+		tmb:              parentTmb, // if datachannel dies, so should we
+		streamOutputChan: ch,
+	}
+
+	return &plugin, nil
+}
+
+// Receive takes input from a client using the MRZAP datachannel and returns output via the MRZAP datachannel
+func (k *ShellPlugin) Receive(action string, actionPayload []byte) (string, []byte, error) {
+	k.logger.Infof("Plugin received Data message with %v action", action)
+
+	// parse action
+	parsedAction := strings.Split(action, "/")
+	if len(parsedAction) < 2 {
+		return "", []byte{}, fmt.Errorf("malformed action: %s", action)
+	}
+	if datachannel.PluginName(parsedAction[0]) != datachannel.Shell {
+		return "", []byte{}, fmt.Errorf("malformed action: expected 'shell/.*' got %s", action)
+	}
+
+	shellAction := parsedAction[1]
+
+	// TODO: The below line removes the extra, surrounding quotation marks that get added at some point in the marshal/unmarshal
+	// so it messes up the umarshalling into a valid action payload.  We need to figure out why this is happening
+	// so that we can murder its family
+	if len(actionPayload) > 0 {
+		actionPayload = actionPayload[1 : len(actionPayload)-1]
+	}
+
+	// Json unmarshalling encodes bytes in base64
+	actionPayloadSafe, base64Err := base64.StdEncoding.DecodeString(string(actionPayload))
+	if base64Err != nil {
+		k.logger.Errorf("error decoding actionPayload: %v", base64Err)
+		return "", []byte{}, base64Err
+	}
+
+	switch bzshell.ShellAction(shellAction) {
+	case bzshell.ShellOpen:
+		if err := k.open(); err != nil {
+			errorString := fmt.Errorf("Unable to start shell: %s", err)
+			k.logger.Error(errorString)
+			time.Sleep(2 * time.Second)
+			return "", []byte{}, errorString
+		}
+	case bzshell.ShellClose:
+		if err := k.close(); err != nil {
+			rerr := fmt.Errorf("Shell stop failed %v", err)
+			k.logger.Error(rerr)
+			return action, []byte{}, rerr
+		}
+	case bzshell.ShellInput:
+		var shellInput bzshell.ShellInputMessage
+
+		if err := json.Unmarshal(actionPayloadSafe, &shellInput); err != nil {
+			rerr := fmt.Errorf("Malformed shell input payload %v", actionPayload)
+			k.logger.Error(rerr)
+			return action, []byte{}, rerr
+		}
+
+		if err := k.shellInput(shellInput); err != nil {
+			rerr := fmt.Errorf("Write to stdin failed %v", err)
+			k.logger.Error(rerr)
+			return action, []byte{}, rerr
+		}
+	case bzshell.ShellResize:
+		var shellResize bzshell.ShellResizeMessage
+
+		if err := json.Unmarshal(actionPayloadSafe, &shellResize); err != nil {
+			rerr := fmt.Errorf("Malformed shell resize payload %v", actionPayload)
+			k.logger.Error(rerr)
+			return action, []byte{}, rerr
+		}
+
+		if err := k.setSize(shellResize.Cols, shellResize.Rows); err != nil {
+			rerr := fmt.Errorf("Shell resize failed %v", err)
+			k.logger.Error(rerr)
+			return action, []byte{}, rerr
+		}
+	}
+
+	return action, []byte{}, nil
+}
+
+func (k *ShellPlugin) Ready() bool {
+	return !(k.stdin == nil || k.stdout == nil)
+}
+
+var startPty = func(
+	logger *logger.Logger,
+	runAsUser string,
+	commands string,
+	plugin *ShellPlugin) (err error) {
+
+	return StartPty(logger, runAsUser, commands, plugin)
+}
+
+func (k *ShellPlugin) open() error {
+	// If this method "open" is called twice is means something has gone very
+	//  wrong and failing early is the safest action.
+	if k.shellStarted == true {
+		return fmt.Errorf("Attempted to start the shell but a call to open a shell has already been made")
+	}
+	k.shellStarted = true
+	commands := ""
+
+	// Catch that the tomb is dying and signal shell to close
+	go func() {
+		<-k.tmb.Dying()
+		if k.execCmd != nil {
+			if err := k.execCmd.Kill(); err != nil {
+				k.logger.Errorf("unable to terminate pty: %s", err)
+			}
+		}
+	}()
+
+	// Start pseudo terminal
+	if err := startPty(k.logger, k.runAsUser, commands, k); err != nil {
+		return err
+	}
+
+	// Start to read from shell and write to datachannel
+	k.logger.Debugf("Start separate go routine to read from pty stdout and write to data channel")
+	done := make(chan int, 1)
+	go func() {
+		done <- k.writePump(k.logger)
+	}()
+
+	return nil
+}
+
+// ctose closes pty file
+func (k *ShellPlugin) close() (err error) {
+	k.logger.Info("Stopping pty")
+	if err := ptyFile.Close(); err != nil {
+		if err, ok := err.(*os.PathError); ok && err.Err != os.ErrClosed {
+			return fmt.Errorf("unable to close ptyFile. %s", err)
+		}
+	}
+	return nil
+}
+
+// shellInput passes payload byte stream to shell stdin
+func (k *ShellPlugin) shellInput(shellInput bzshell.ShellInputMessage) error {
+	if k.Ready() == false {
+		// This is to handle scenario when cli/console starts sending size data but pty has not been started yet
+		// Since packets are rejected, cli/console will resend these packets until pty starts successfully in separate thread
+		k.logger.Tracef("Pty unavailable. Reject incoming message packet")
+		return errors.New("message handler is not ready, rejecting incoming packet")
+	}
+
+	k.logger.Tracef("Input message received: ")
+	instr, err := base64.StdEncoding.DecodeString(string(shellInput.Data))
+	if err != nil {
+		k.logger.Errorf("Shell stdout stream base64 decode failed: %v", err)
+		return err
+	}
+	if _, err := k.stdin.Write(instr); err != nil {
+		k.logger.Errorf("Unable to write to stdin, err: %v.", err)
+		return err
+	}
+
+	return nil
+}
+
+// setSize resizes the pseudo-terminal pty
+func (k *ShellPlugin) setSize(cols, rows uint32) (err error) {
+	k.logger.Tracef("Pty Resize data received: cols: %d, rows: %d", cols, rows)
+	if err := SetSize(k.logger, cols, rows); err != nil {
+		k.logger.Errorf("Unable to set pty size: %s", err)
+		return err
+	}
+	return nil
+}
+
+// writePump reads from pty stdout and writes to data channel.
+func (k *ShellPlugin) writePump(logger *logger.Logger) int {
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Println("WritePump thread crashed with message: \n", err)
+			logger.Errorf("Stacktrace:\n%s", debug.Stack())
+		}
+	}()
+
+	stdoutBytes := make([]byte, config.StreamDataPayloadSize)
+	reader := bufio.NewReader(k.stdout)
+
+	// Wait for all input commands to run.
+	time.Sleep(time.Second)
+
+	sequenceNumber := 1
+
+	for {
+		stdoutBytesLen, err := reader.Read(stdoutBytes)
+		if err != nil {
+			fmt.Println("WritePump failed when reading from stdout: \n", err)
+			logger.Errorf("Stacktrace:\n%s", debug.Stack())
+			return config.ErrorExitCode
+		}
+
+		str := base64.StdEncoding.EncodeToString(stdoutBytes[:stdoutBytesLen])
+
+		message := smsg.StreamMessage{
+			Type:           string(smsg.StdOut),
+			RequestId:      "shell", // not needed for shell because we aren't multiplexing sessions over a shared data channel
+			SequenceNumber: sequenceNumber,
+			Content:        str,
+			LogId:          "", // only used for kube plugin
+		}
+
+		k.streamOutputChan <- message
+		sequenceNumber++
+
+		// Wait for stdout to process more data
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/bctl/agent/plugin/shell/shell_test.go
+++ b/bctl/agent/plugin/shell/shell_test.go
@@ -1,0 +1,255 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package shell
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"testing"
+
+	"bastionzero.com/bctl/v1/bctl/agent/utility"
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/tomb.v2"
+)
+
+func MockLogger() *logger.Logger {
+	logger, err := logger.New(logger.Debug, "/dev/null")
+	if err == nil {
+		return logger
+	} else {
+		return nil
+	}
+}
+
+func GetRunAsUser(t *testing.T) string {
+	username, err := utility.WhoAmI()
+	if err != nil {
+		t.Errorf("Could not resolve username: %v", err)
+	}
+	return username
+}
+
+func StreamMessageToString(t *testing.T, msg smsg.StreamMessage) string {
+	msgbyte, err := base64.StdEncoding.DecodeString(string(msg.Content))
+	if err != nil {
+		t.Errorf("Shell stdout stream base64 decode failed: %v", err)
+	}
+	return string(msgbyte)
+}
+
+func SpawnTerminal(t *testing.T, streamOutputChan chan smsg.StreamMessage) *ShellPlugin {
+	subLogger := MockLogger().GetPluginLogger(string("unittest shell"))
+	testshelluser := GetRunAsUser(t)
+
+	var tmb tomb.Tomb
+	synPayload, _ := json.Marshal(bzshell.ShellConfigParams{
+		RunAsUser: testshelluser,
+	})
+	plugin, err := New(&tmb, subLogger, streamOutputChan, synPayload)
+	if err != nil {
+		t.Errorf("Shell plugin new failed: %v", err.Error())
+	}
+	if plugin == nil {
+		t.Errorf("Plugin is nil")
+	}
+	var action = "shell/open"
+
+	openPayload, _ := json.Marshal(bzshell.ShellOpenMessage{})
+	b64payload := b64Encode(openPayload)
+
+	respstr, respbytes, err := plugin.Receive(action, b64payload)
+
+	if err != nil {
+		t.Errorf("Shell start threw error: %v", err)
+	}
+
+	assert.NotNil(t, respbytes)
+	assert.NotEmpty(t, respstr)
+
+	time.Sleep(1 * time.Second)
+
+	return plugin
+}
+
+func SendResize(t *testing.T, plugin *ShellPlugin, rows uint32, cols uint32) {
+	action := "shell/resize"
+
+	resizePayload, _ := json.Marshal(bzshell.ShellResizeMessage{
+		Rows: rows,
+		Cols: cols,
+	})
+	b64payload := b64Encode(resizePayload)
+
+	respstr, respbytes, err := plugin.Receive(action, b64payload)
+	if err != nil {
+		t.Errorf("Shell input threw error: %v", err)
+	}
+
+	assert.NotNil(t, respbytes)
+	assert.NotEmpty(t, respstr)
+}
+
+func SendClose(t *testing.T, plugin *ShellPlugin) {
+	action := "shell/close"
+
+	closePayload, _ := json.Marshal(bzshell.ShellCloseMessage{})
+	b64payload := b64Encode(closePayload)
+
+	respstr, respbytes, err := plugin.Receive(action, b64payload)
+	if err != nil {
+		t.Errorf("Shell input threw error: %v", err)
+	}
+
+	assert.NotNil(t, respbytes)
+	assert.NotEmpty(t, respstr)
+}
+
+func b64Encode(b []byte) []byte {
+	// Adds quotes as the base64 encoded strings which receive gets over the data channel has quotes
+	return []byte("\"" + base64.StdEncoding.EncodeToString(b) + "\"")
+}
+
+func SendToStdIn(t *testing.T, plugin *ShellPlugin, stdinstr string) {
+	action := "shell/input"
+
+	b64input := base64.StdEncoding.EncodeToString([]byte(stdinstr))
+	inputPayload, _ := json.Marshal(bzshell.ShellInputMessage{
+		Data: b64input,
+	})
+	b64payload := b64Encode(inputPayload)
+
+	respstr, respbytes, err := plugin.Receive(action, b64payload)
+	if err != nil {
+		t.Errorf("Shell input threw error: %v", err)
+	}
+
+	assert.NotNil(t, respbytes)
+	assert.NotEmpty(t, respstr)
+}
+
+// This function ensures that if the channel doesn't receive any output the test won't hang forever
+//  TODO: I don't like this pattern. I should replace it write an anonymous function that writes to a buffer
+func ReadOutputOrTimeout(t *testing.T, ch chan smsg.StreamMessage) (string, error) {
+	select {
+	case msg := <-ch:
+		msgstr := StreamMessageToString(t, msg)
+		return msgstr, nil
+	case <-time.After(3000 * time.Millisecond):
+		t.Errorf("Output Channel read timeout")
+		return "", fmt.Errorf("Channel read timedout")
+	}
+}
+
+func TestInputOutput(t *testing.T) {
+	streamOutputChan := make(chan smsg.StreamMessage, 20)
+
+	plugin := SpawnTerminal(t, streamOutputChan)
+	assert.NotNil(t, plugin)
+
+	outstr, err := ReadOutputOrTimeout(t, streamOutputChan)
+	assert.Nil(t, err)
+
+	t.Logf("Terminal says: %v", outstr)
+	assert.Contains(t, outstr, "sh")
+
+	lscmd := "ls -l\n"
+	SendToStdIn(t, plugin, lscmd)
+
+	outstr, err = ReadOutputOrTimeout(t, streamOutputChan)
+	assert.Nil(t, err)
+	assert.EqualValues(t, strings.TrimSpace(lscmd), strings.TrimSpace(outstr)) // Shell should always reflect back the entered command
+
+	outstr, err = ReadOutputOrTimeout(t, streamOutputChan)
+	assert.Nil(t, err)
+	assert.Contains(t, outstr, "total") // ls -l always returns total as the first line
+}
+
+func TestResize(t *testing.T) {
+
+	streamOutputChan := make(chan smsg.StreamMessage, 20)
+
+	plugin := SpawnTerminal(t, streamOutputChan)
+	assert.NotNil(t, plugin)
+	outstr, err := ReadOutputOrTimeout(t, streamOutputChan)
+	assert.Nil(t, err)
+
+	assert.Contains(t, outstr, "sh")
+
+	rows := uint32(23)
+	cols := uint32(5)
+	SendResize(t, plugin, rows, cols)
+	// This test checks that Shell/Resize doesn't throw an error, it does not confirm that the terminal was resized correctly
+}
+
+func TestClose(t *testing.T) {
+	streamOutputChan := make(chan smsg.StreamMessage, 20)
+
+	plugin := SpawnTerminal(t, streamOutputChan)
+	assert.NotNil(t, plugin)
+	outstr, err := ReadOutputOrTimeout(t, streamOutputChan)
+	assert.Nil(t, err)
+
+	assert.Contains(t, outstr, "sh")
+
+	SendClose(t, plugin)
+
+	action := "shell/input"
+	b64instr := base64.StdEncoding.EncodeToString([]byte("ls -l\n"))
+	inputPayload, _ := json.Marshal(bzshell.ShellInputMessage{
+		Data: b64instr,
+	})
+	b64payload := b64Encode(inputPayload)
+
+	// Throw an error because the shell is now closed
+	_, _, err = plugin.Receive(action, b64payload)
+	if err == nil {
+		t.Errorf("Error expected. shell/close should cause shell/input to fail")
+	}
+}
+
+func TestNoUserExistsErr(t *testing.T) {
+
+	streamOutputChan := make(chan smsg.StreamMessage, 20)
+
+	subLogger := MockLogger().GetPluginLogger(string("unittest shell"))
+	var tmb tomb.Tomb
+
+	userThatDoesNotExist := "NoSuchUser"
+
+	synPayload, _ := json.Marshal(bzshell.ShellConfigParams{
+		RunAsUser: userThatDoesNotExist,
+	})
+	plugin, err := New(&tmb, subLogger, streamOutputChan, synPayload)
+	if err != nil {
+		t.Errorf("Shell plugin new failed: %v", err.Error())
+	}
+	if plugin == nil {
+		t.Errorf("Plugin is nil")
+	}
+	var action = "shell/open"
+
+	openPayload, _ := json.Marshal(bzshell.ShellOpenMessage{})
+	b64payload := b64Encode(openPayload)
+
+	_, _, err = plugin.Receive(action, b64payload)
+
+	assert.EqualError(t, err, "Unable to start shell: failed to start pty since RunAs user NoSuchUser does not exist")
+}

--- a/bctl/agent/plugin/shell/shell_unix.go
+++ b/bctl/agent/plugin/shell/shell_unix.go
@@ -1,0 +1,205 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This code has been modified from the code covered by the Apache License 2.0.
+// Modifications Copyright (C) 2022 BastionZero Inc.  The BastionZero Agent
+// is licensed under the Apache 2.0 License.
+
+//go:build darwin || freebsd || linux || netbsd || openbsd
+// +build darwin freebsd linux netbsd openbsd
+
+// Package shell implements session shell plugin.
+package shell
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"bastionzero.com/bctl/v1/bctl/agent/plugin/shell/execcmd"
+	"bastionzero.com/bctl/v1/bctl/agent/utility"
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	"github.com/creack/pty"
+)
+
+var ptyFile *os.File
+
+const (
+	termEnvVariable       = "TERM=xterm-256color"
+	langEnvVariable       = "LANG=C.UTF-8"
+	langEnvVariableKey    = "LANG"
+	startRecordSessionCmd = "script"
+	newLineCharacter      = "\n"
+	catCmd                = "cat"
+	scriptFlag            = "-c"
+	homeEnvVariable       = "HOME=/home/"
+	groupsIdentifier      = "groups="
+)
+
+//StartPty starts pty and provides handles to stdin and stdout
+// isSessionLogger determines whether its a customer shell or shell used for logging.
+func StartPty(
+	logger *logger.Logger,
+	runAsUser string,
+	commandstr string,
+	plugin *ShellPlugin) (err error) {
+
+	logger.Info("Starting pty")
+	//Start the command with a pty
+	var cmd *exec.Cmd
+
+	if strings.TrimSpace(commandstr) == "" {
+		cmd = exec.Command("sh")
+	} else {
+		commandArgs := append(utility.ShellPluginCommandArgs, commandstr)
+		cmd = exec.Command("sh", commandArgs...)
+	}
+
+	//TERM is set as linux by pty which has an issue where vi editor screen does not get cleared.
+	//Setting TERM as xterm-256color as used by standard terminals to fix this issue
+	cmd.Env = append(os.Environ(), termEnvVariable)
+
+	//If LANG environment variable is not set, shell defaults to POSIX which can contain 256 single-byte characters.
+	//Setting C.UTF-8 as default LANG environment variable as Session Manager supports UTF-8 encoding only.
+	langEnvVariableValue := os.Getenv(langEnvVariableKey)
+	if langEnvVariableValue == "" {
+		cmd.Env = append(cmd.Env, langEnvVariable)
+	}
+
+	var sessionUser string
+
+	if strings.TrimSpace(runAsUser) == "" {
+		return errors.New("please set the RunAs default user")
+	}
+
+	// Check if user exists
+	if userExists, _ := utility.DoesUserExist(runAsUser); !userExists {
+		// if user does not exist, fail the session
+		return fmt.Errorf("failed to start pty since RunAs user %s does not exist", runAsUser)
+	}
+
+	sessionUser = runAsUser
+
+	// Get the uid and gid of the runas user.
+	uid, gid, groups, err := getUserCredentials(logger, sessionUser)
+	if err != nil {
+		return err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	// Changed NoSetGroups = true (was NoSetGroups = false) because it doesn't work when set to true
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid, Groups: groups, NoSetGroups: true}
+
+	// Setting home environment variable for RunAs user
+	runAsUserHomeEnvVariable := homeEnvVariable + sessionUser
+	cmd.Env = append(cmd.Env, runAsUserHomeEnvVariable)
+
+	ptyFile, err = pty.Start(cmd)
+
+	if err != nil {
+		logger.Errorf("Failed to start pty: %s\n", err)
+		return fmt.Errorf("Failed to start pty: %s", err)
+	}
+
+	plugin.stdin = ptyFile
+	plugin.stdout = ptyFile
+	plugin.runAsUser = sessionUser
+	plugin.execCmd = execcmd.NewExecCmd(cmd)
+
+	return nil
+}
+
+// SetSize sets size of console terminal window.
+func SetSize(logger *logger.Logger, ws_col, ws_row uint32) (err error) {
+	winSize := pty.Winsize{
+		Cols: uint16(ws_col),
+		Rows: uint16(ws_row),
+	}
+
+	if err := pty.Setsize(ptyFile, &winSize); err != nil {
+		return fmt.Errorf("set pty size failed: %s", err)
+	}
+	return nil
+}
+
+// getUserCredentials returns the uid, gid and groups associated to the runas user.
+func getUserCredentials(logger *logger.Logger, sessionUser string) (uint32, uint32, []uint32, error) {
+	uidCmdArgs := append(utility.ShellPluginCommandArgs, fmt.Sprintf("id -u %s", sessionUser))
+	cmd := exec.Command(utility.ShellPluginCommandName, uidCmdArgs...)
+	out, err := cmd.Output()
+	if err != nil {
+		logger.Errorf("Failed to retrieve uid for %s: %v", sessionUser, err)
+		return 0, 0, nil, err
+	}
+
+	uid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		logger.Errorf("%s not found: %v", sessionUser, err)
+		return 0, 0, nil, err
+	}
+
+	gidCmdArgs := append(utility.ShellPluginCommandArgs, fmt.Sprintf("id -g %s", sessionUser))
+	cmd = exec.Command(utility.ShellPluginCommandName, gidCmdArgs...)
+	out, err = cmd.Output()
+	if err != nil {
+		logger.Errorf("Failed to retrieve gid for %s: %v", sessionUser, err)
+		return 0, 0, nil, err
+	}
+
+	gid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		logger.Errorf("%s not found: %v", sessionUser, err)
+		return 0, 0, nil, err
+	}
+
+	// Get the list of associated groups
+	groupNamesCmdArgs := append(utility.ShellPluginCommandArgs, fmt.Sprintf("id %s", sessionUser))
+	cmd = exec.Command(utility.ShellPluginCommandName, groupNamesCmdArgs...)
+	out, err = cmd.Output()
+	if err != nil {
+		logger.Errorf("Failed to retrieve groups for %s: %v", sessionUser, err)
+		return 0, 0, nil, err
+	}
+
+	// Example format of output: uid=1873601143(ssm-user) gid=1873600513(domain users) groups=1873600513(domain users),1873601620(joiners),1873601125(aws delegated add workstations to domain users)
+	// Extract groups from the output
+	groupsIndex := strings.Index(string(out), groupsIdentifier)
+	var groupIds []uint32
+
+	if groupsIndex > 0 {
+		// Extract groups names and ids from the output
+		groupNamesAndIds := strings.Split(string(out)[groupsIndex+len(groupsIdentifier):], ",")
+
+		// Extract group ids from the output
+		for _, value := range groupNamesAndIds {
+			groupId, err := strconv.Atoi(strings.TrimSpace(value[:strings.Index(value, "(")]))
+			if err != nil {
+				logger.Errorf("Failed to retrieve group id from %s: %v", value, err)
+				return 0, 0, nil, err
+			}
+
+			groupIds = append(groupIds, uint32(groupId))
+		}
+	}
+
+	// Make sure they are non-zero valid positive ids
+	// As user 'root' is by convention uid=0, gid=0 this disallows starting the terminal as root
+	if uid > 0 && gid > 0 {
+		return uint32(uid), uint32(gid), groupIds, nil
+	}
+
+	return 0, 0, nil, errors.New("invalid uid and gid")
+}

--- a/bctl/agent/plugin/web/web.go
+++ b/bctl/agent/plugin/web/web.go
@@ -49,7 +49,7 @@ func New(parentTmb *tomb.Tomb,
 	// Unmarshal the Syn payload
 	var synPayload bzweb.WebActionParams
 	if err := json.Unmarshal(payload, &synPayload); err != nil {
-		return &WebPlugin{}, fmt.Errorf("malformed Db plugin SYN payload %v", string(payload))
+		return &WebPlugin{}, fmt.Errorf("malformed Web plugin SYN payload %v", string(payload))
 	}
 
 	// Determine if we are using target hostname or host:port
@@ -124,7 +124,7 @@ func (k *WebPlugin) Receive(action string, actionPayload []byte) (string, []byte
 		subLogger.AddRequestId(rid)
 		switch bzweb.WebAction(webAction) {
 		case bzweb.Dial:
-			// Create a new dbdial action
+			// Create a new webdial action
 			a, err := webdial.New(subLogger, k.tmb, k.streamOutputChan, k.remoteAddress)
 			k.updateActionsMap(a, rid) // save action for later input
 
@@ -138,7 +138,7 @@ func (k *WebPlugin) Receive(action string, actionPayload []byte) (string, []byte
 			action, payload, err := a.Receive(action, actionPayloadSafe)
 			return action, payload, err
 		default:
-			rerr := fmt.Errorf("unhandled db action: %v", action)
+			rerr := fmt.Errorf("unhandled web action: %v", action)
 			k.logger.Error(rerr)
 			return "", []byte{}, rerr
 		}

--- a/bctl/agent/utility/utility_unix.go
+++ b/bctl/agent/utility/utility_unix.go
@@ -1,0 +1,74 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// This code has been modified from the code covered by the Apache License 2.0.
+// Modifications Copyright (C) 2022 BastionZero Inc.  The BastionZero SSM Agent
+// is licensed under the Apache 2.0 License.
+
+//go:build darwin || freebsd || linux || netbsd || openbsd
+// +build darwin freebsd linux netbsd openbsd
+
+// utility package implements all the shared methods between clients.
+package utility
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+var ShellPluginCommandName = "sh"
+var ShellPluginBashCommandName = "/bin/bash"
+var ShellPluginCommandArgs = []string{"-c"}
+
+var DefaultRunAsUser = "bzuser"
+
+const (
+	sudoersFile     = "/etc/sudoers.d/ssm-agent-users"
+	sudoersFileMode = 0440
+	fs_ioc_getflags = uintptr(0x80086601)
+	fs_ioc_setflags = uintptr(0x40086602)
+	FS_APPEND_FL    = 0x00000020 /* writes to file may only append */
+	FS_RESET_FL     = 0x00000000 /* reset file property */
+)
+
+// DoesUserExist checks if given user already exists
+func DoesUserExist(username string) (bool, error) {
+
+	shellCmdArgs := append(ShellPluginCommandArgs, fmt.Sprintf("id %s", username))
+	cmd := exec.Command(ShellPluginCommandName, shellCmdArgs...)
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			return false, fmt.Errorf("encountered an error while checking for %s: %v", DefaultRunAsUser, exitErr.Error())
+		}
+		return false, nil
+	}
+	return true, nil
+}
+
+// WhoAmI returns the current username that the agent is running under
+func WhoAmI() (string, error) {
+	cmdstr := "whoami"
+	shellCmdArgs := append(ShellPluginCommandArgs, cmdstr)
+	cmd := exec.Command(ShellPluginCommandName, shellCmdArgs...)
+	stdout, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// The program has exited with an exit code != 0
+			return "", fmt.Errorf("encountered an error while running command %v : %v", cmdstr, exitErr.Error())
+		}
+		return "", nil
+	}
+
+	return string(stdout), nil
+}

--- a/bctl/go.mod
+++ b/bctl/go.mod
@@ -8,9 +8,12 @@ replace bastionzero.com/bctl/v1/bctl => ./
 
 require (
 	bastionzero.com/bctl/v1/bzerolib v0.0.0
+	github.com/creack/pty v1.1.17 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.2.0
 	github.com/ovh/configstore v0.5.2 // indirect
-	github.com/tucnak/store v0.0.0-20170905113834-b02ecdcc6dfb // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/tucnak/store v0.0.0-20170905113834-b02ecdcc6dfb
 	golang.org/x/build v0.0.0-20211108163316-3ce30f35b9aa
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	k8s.io/api v0.21.3

--- a/bctl/go.sum
+++ b/bctl/go.sum
@@ -166,6 +166,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.15/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -356,6 +358,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -699,6 +703,7 @@ github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.0/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/bzerolib/go.sum
+++ b/bzerolib/go.sum
@@ -165,6 +165,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.15/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cznic/mathutil v0.0.0-20180504122225-ca4c9f2c1369/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -353,6 +355,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210715191844-86eeefc3e471/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -598,6 +601,7 @@ github.com/openzipkin-contrib/zipkin-go-opentracing v0.4.5/go.mod h1:/wsWhb9smxS
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/ovh/configstore v0.5.2/go.mod h1:krvoiDcrESKjEOz6AnKD8EbCmqHHQyOzEJNhAIhB4+Y=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -704,6 +708,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tucnak/store v0.0.0-20170905113834-b02ecdcc6dfb/go.mod h1:l43Yq5ssn3bAYymDCtVEXY7puaPpFo1zhx1e3KS+RcY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=

--- a/bzerolib/plugin/shell/shell.go
+++ b/bzerolib/plugin/shell/shell.go
@@ -1,0 +1,40 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package shell
+
+type ShellOpenMessage struct{}
+
+type ShellCloseMessage struct{}
+
+type ShellInputMessage struct {
+	Data string `json:"data"`
+}
+
+type ShellResizeMessage struct {
+	Cols uint32 `json:"cols"`
+	Rows uint32 `json:"rows"`
+}
+
+type ShellConfigParams struct {
+	RunAsUser string `json:"runasuser"`
+}
+
+type ShellAction string
+
+const (
+	ShellOpen   ShellAction = "open"
+	ShellClose  ShellAction = "close"
+	ShellResize ShellAction = "resize"
+	ShellInput  ShellAction = "input"
+)


### PR DESCRIPTION
## Description of the change

This creates an interactive shell plugin for the SystemD agent. This PR includes unit tests for the open, close, input, resize actions are work.

To run the unittests for this feature
```
cd bzero/bctl
 go test bastionzero.com/bctl/v1/bctl/agent/plugin/shel
```

I've confirmed it passes tests on OSX and AWS centoOS (see image)

<img width="1099" alt="Screen Shot 2022-01-20 at 6 00 00 PM" src="https://user-images.githubusercontent.com/274814/150435699-d0196e69-4888-4468-95cc-3c8bf715a12f.png">

One odd thing that I encountered is that the shell launch fails both on linux and osx if `NoSetGroups = false` which is how the AWS-SSM-Agent is configured.

```golang
cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid, Groups: groups, NoSetGroups: true}
```
I was unable to figure out why this would fail in my code but work fine in the [bzero SSM-agent](https://github.com/bastionzero/bzero-ssm-agent/blob/bzero-dev/agent/session/shell/shell_unix.go#L137). Open to any ideas about what is going on here.

### Additional work left undone

1. Create and attach the shell plugin to a datachannel in the agent **(out of scope)**
2. Provide unittests from datachannel to agent **(out of scope)**
3. Does not create the local agent user account 'bzuser' a.k.a. the DefaultRunAsUser **(out of scope)**
4. Create a mock pty. This was a more complex task than anticipated so I wrote the unittests to use shell account of whoever runs the test 
5. Didn't break action handlers into their own files with receive message. Don't feel particular strongly one way or the other but the code was fairly inter-related and it seemed easy just to keep it in the same file for now.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: [CWC-1419](https://commonwealthcrypto.atlassian.net/browse/CWC-1419)

## Have you considered the security impacts?

Does this PR have any security impact?

- [X] Yes
- [ ] No

If yes, please explain:

The shell plugin attempts to place the user in shell with linux user account enforced by the bastion. The dangerous exists that the user could escape from this user account and escalate to the privileges held by the agent. To avoid introducing additional security issues this code attempts to inherent as much as the shell launching code for the bastion-zero ssm-agent.

In future PRs when connecting the shell plugin to the agent, we should ensure that the user not able to override the linux user account set by the bastion.