### PR TITLE
Adds echooutput action to shell plugin

### DIFF
--- a/bctl/agent/plugin/shell/shell_unix.go
+++ b/bctl/agent/plugin/shell/shell_unix.go
@@ -123,10 +123,10 @@ func StartPty(
 }
 
 // SetSize sets size of console terminal window.
-func SetSize(logger *logger.Logger, ws_col, ws_row uint32) (err error) {
+func SetSize(logger *logger.Logger, wsCol, wRow uint32) (err error) {
 	winSize := pty.Winsize{
-		Cols: uint16(ws_col),
-		Rows: uint16(ws_row),
+		Cols: uint16(wsCol),
+		Rows: uint16(wRow),
 	}
 
 	if err := pty.Setsize(ptyFile, &winSize); err != nil {

--- a/bzerolib/plugin/shell/shell.go
+++ b/bzerolib/plugin/shell/shell.go
@@ -26,6 +26,8 @@ type ShellResizeMessage struct {
 	Rows uint32 `json:"rows"`
 }
 
+type ShellReplayMessage struct{}
+
 type ShellConfigParams struct {
 	RunAsUser string `json:"runasuser"`
 }
@@ -33,8 +35,9 @@ type ShellConfigParams struct {
 type ShellAction string
 
 const (
-	ShellOpen   ShellAction = "open"
-	ShellClose  ShellAction = "close"
-	ShellResize ShellAction = "resize"
-	ShellInput  ShellAction = "input"
+	ShellOpen    ShellAction = "open"
+	ShellClose   ShellAction = "close"
+	ShellResize  ShellAction = "resize"
+	ShellInput   ShellAction = "input"
+	ShelllReplay ShellAction = "replay"
 )

--- a/bzerolib/ringbuffer/ringbuffer.go
+++ b/bzerolib/ringbuffer/ringbuffer.go
@@ -1,0 +1,136 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ringbuffer
+
+import (
+	"fmt"
+)
+
+func min(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+func max(a int, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// RingBuffer this implements fixed size ringbuffer a.k.a. a cyclic buffer.
+type RingBuffer struct {
+	buffer     []byte
+	size       int
+	start, end int
+	full       bool
+}
+
+// New is the RingBuffer constructor
+func New(size int) *RingBuffer {
+	var rb = RingBuffer{
+		buffer: make([]byte, size),
+		size:   size,
+		start:  0,
+		end:    0,
+		full:   false,
+	}
+	return &rb
+}
+
+func (r *RingBuffer) sanitycheck() (err error) {
+	if r.start >= r.size {
+		return fmt.Errorf("Ringbuffer sanity check failed (start > size) start=%d, end=%d, size=%d", r.start, r.end, r.size)
+	}
+	if r.end > r.size {
+		return fmt.Errorf("Ringbuffer sanity check failed (end > size) start=%d, end=%d, size=%d", r.start, r.end, r.size)
+	}
+	if r.start < 0 {
+		return fmt.Errorf("Ringbuffer sanity check failed (start < 0) start=%d, end=%d, size=%d", r.start, r.end, r.size)
+	}
+	if r.end < 0 {
+		return fmt.Errorf("Ringbuffer sanity check failed (end < 0) start=%d, end=%d, size=%d", r.start, r.end, r.size)
+	}
+	if r.size < 0 {
+		return fmt.Errorf("Ringbuffer sanity check failed (size < 0) start=%d, end=%d, size=%d", r.start, r.end, r.size)
+	}
+
+	// All checks pass
+	return nil
+}
+
+func (r *RingBuffer) Read(p []byte) (n int, err error) {
+	r.sanitycheck()
+
+	// There are two cases:
+	if r.full == false {
+		// Case 1 - The head hasn't eaten it's own tail yet (full == false)
+		//  data in buffer less than buffer size
+		//   --> r.start < r.end < r.size
+		//   --> r.start = 0
+		//   --> datalen = r.size-r.end = r.end - r.start
+		n = min(len(p), r.end-r.start) // Don't try to read more data than exists in the buffer
+	} else {
+		// Case 2 - The head has eaten it's own tail (full == true)
+		//  data in buffer equal to buffer size
+		//   --> r.start == r.end
+		//   --> datalen == r.size
+		n = min(len(p), r.size)
+	}
+
+	readstop := min((r.start + n), r.size)
+	copy(p[:(readstop-r.start)], r.buffer[r.start:readstop])
+
+	// if we have more to read wrap back around
+	if remainder := n - (readstop - r.start); remainder > 0 {
+		copy(p[(readstop-r.start):], r.buffer[0:remainder])
+	}
+
+	return n, nil
+}
+
+func (r *RingBuffer) Write(p []byte) (n int, err error) {
+	r.sanitycheck()
+	n = len(p)
+
+	// Buffer will be full when write completes
+	if r.full == false && (r.end+n) >= r.size {
+		r.full = true
+	}
+
+	// Optimization: if bytes to write larger than the ringbuffer, skip the writing bytes that will be overwritten.
+	if n >= r.size {
+		copy(r.buffer[:], p[n-r.size:]) // just write the last r.size bytes
+		r.start = 0                     // reset the ringbuffer to start from the begining
+		r.end = 0
+		return r.size, nil
+	}
+
+	writestop := min((r.end + n), r.size)
+	copy(r.buffer[r.end:writestop], p[:writestop-r.end])
+
+	// if we have more to read wrap back around
+	if remainder := max(0, n-(writestop-r.end)); remainder > 0 {
+		copy(r.buffer[:remainder], p[writestop-r.end:])
+	}
+
+	r.end = (r.end + n) % r.size
+	if r.full == true {
+		// head eats tail
+		r.start = r.end
+	}
+
+	return n, nil
+}

--- a/bzerolib/ringbuffer/ringbuffer_test.go
+++ b/bzerolib/ringbuffer/ringbuffer_test.go
@@ -1,0 +1,277 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ringbuffer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyRingBuffer(t *testing.T) {
+	rb := New(0)
+	assert.NotNil(t, rb)
+
+	buff := make([]byte, 10)
+
+	n, err := rb.Read(buff)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
+}
+
+func TestSimpleWriteReads(t *testing.T) {
+	wbuff0 := []byte{}
+	wbuff2 := []byte{0x11, 0x12}
+	wbuff3 := []byte{0xa, 0xb, 0xc}
+
+	wbuff9 := []byte{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}
+
+	rbuff0 := make([]byte, 1)
+	rbuff1 := make([]byte, 1)
+	rbuff5 := make([]byte, 5)
+	rbuff7 := make([]byte, 7)
+
+	rblen := 7
+	rb := New(rblen)
+	assert.NotNil(t, rb)
+
+	n, err := rb.Read(rbuff0)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
+
+	n, err = rb.Read(rbuff7)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
+	assert.EqualValues(t, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, rbuff7)
+
+	n, err = rb.Write(wbuff9)
+	assert.Nil(t, err)
+	assert.EqualValues(t, rblen, n)
+
+	n, err = rb.Read(rbuff7)
+	assert.EqualValues(t, 7, n)
+	assert.EqualValues(t, []byte{0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9}, rbuff7)
+
+	n, err = rb.Read(rbuff1)
+	assert.EqualValues(t, 1, n)
+	assert.EqualValues(t, []byte{0x3}, rbuff1)
+
+	n, err = rb.Write(wbuff3)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 3, n)
+
+	n, err = rb.Write(wbuff0)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
+
+	n, err = rb.Read(rbuff5)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x6, 0x7, 0x8, 0x9, 0xa}, rbuff5)
+
+	n, err = rb.Write(wbuff2)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+
+	n, err = rb.Read(rbuff7)
+	assert.EqualValues(t, 7, n)
+	assert.EqualValues(t, []byte{0x8, 0x9, 0xa, 0xb, 0xc, 0x11, 0x12}, rbuff7)
+
+	n, err = rb.Write(wbuff0)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 0, n)
+
+	n, err = rb.Read(rbuff7)
+	assert.EqualValues(t, 7, n)
+	assert.EqualValues(t, []byte{0x8, 0x9, 0xa, 0xb, 0xc, 0x11, 0x12}, rbuff7)
+}
+
+func TestEdgeCases(t *testing.T) {
+	wbuff1 := []byte{0x01}
+	wbuff2 := []byte{0x11, 0x12}
+	wbuff3 := []byte{0x21, 0x22, 0x23}
+	wbuff4 := []byte{0x31, 0x32, 0x33, 0x34}
+	wbuff5 := []byte{0x41, 0x42, 0x43, 0x44, 0x45}
+	wbuff6 := []byte{0x51, 0x52, 0x53, 0x54, 0x55, 0x56}
+
+	rbuff1 := make([]byte, 1)
+	rbuff2 := make([]byte, 2)
+	rbuff3 := make([]byte, 3)
+	rbuff4 := make([]byte, 4)
+	rbuff5 := make([]byte, 5)
+	rbuff6 := make([]byte, 6)
+
+	rblen := 5
+	rb := New(rblen)
+	assert.NotNil(t, rb)
+
+	// write 0x11, 0x12 --> (head)0x11, 0x12, (tail)0x00, 0x00, 0x00
+	n, err := rb.Write(wbuff2)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff2), n)
+
+	n, err = rb.Read(rbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 1, n)
+	assert.EqualValues(t, []byte{0x11}, rbuff1)
+
+	n, err = rb.Read(rbuff2)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+	assert.EqualValues(t, []byte{0x11, 0x12}, rbuff2)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x00, 0x00}, rbuff4)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x00, 0x00, 0x00}, rbuff5)
+
+	n, err = rb.Read(rbuff6)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 2, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x00, 0x00, 0x00, 0x00}, rbuff6)
+
+	// write 0x01 --> (head)0x11, 0x12, 0x01, (tail)0x00, 0x00
+	n, err = rb.Write(wbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff1), n)
+
+	n, err = rb.Read(rbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 1, n)
+	assert.EqualValues(t, []byte{0x11}, rbuff1)
+
+	n, err = rb.Read(rbuff3)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 3, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01}, rbuff3)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 3, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x00}, rbuff4)
+
+	// write 0x01 --> (head)0x11, 0x12, 0x01, 0x01, (tail)0x00
+	n, err = rb.Write(wbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff1), n)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01}, rbuff4)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01, 0x00}, rbuff5)
+
+	n, err = rb.Read(rbuff6)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01, 0x00, 0x00}, rbuff6)
+
+	// write 0x01 --> (tail)(head)0x11, 0x12, 0x01, 0x01, 0x01
+	n, err = rb.Write(wbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff1), n)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01}, rbuff4)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01, 0x01}, rbuff5)
+
+	n, err = rb.Read(rbuff6)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x11, 0x12, 0x01, 0x01, 0x01, 0x00}, rbuff6)
+
+	// write 0x01 --> 0x01, (tail)(head)0x12, 0x01, 0x01, 0x01
+	n, err = rb.Write(wbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff1), n)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x12, 0x01, 0x01, 0x01}, rbuff4)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x12, 0x01, 0x01, 0x01, 0x01}, rbuff5)
+
+	// write 0x21, 0x22, 0x33, --> 0x01, 0x21, 0x22, 0x23, (tail)(head)0x01
+	n, err = rb.Write(wbuff3)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff3), n)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x01, 0x01, 0x21, 0x22, 0x23}, rbuff5)
+
+	n, err = rb.Read(rbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 1, n)
+	assert.EqualValues(t, []byte{0x01}, rbuff1)
+
+	// write 0x41, 0x42, 0x43, 0x44, 0x45 --> 0x42, 0x43, 0x44, 0x45, (tail)(head)0x41
+	n, err = rb.Write(wbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff5), n)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x41, 0x42, 0x43, 0x44, 0x45}, rbuff5)
+
+	n, err = rb.Read(rbuff1)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 1, n)
+	assert.EqualValues(t, []byte{0x41}, rbuff1)
+
+	// write 0x31, 0x32, 0x33, 0x34 --> 0x32, 0x33, 0x34, (tail)(head)0x45, 0x31
+	n, err = rb.Write(wbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, len(wbuff4), n)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x45, 0x31, 0x32, 0x33, 0x34}, rbuff5)
+
+	n, err = rb.Read(rbuff4)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 4, n)
+	assert.EqualValues(t, []byte{0x45, 0x31, 0x32, 0x33}, rbuff4)
+
+	// write 0x51, 0x52, 0x53, 0x54, 0x55, 0x56 --> 0x53, 0x54, 0x55, 0x56, (tail)(head)0x52
+	n, err = rb.Write(wbuff6)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+
+	n, err = rb.Read(rbuff5)
+	assert.Nil(t, err)
+	assert.EqualValues(t, 5, n)
+	assert.EqualValues(t, []byte{0x52, 0x53, 0x54, 0x55, 0x56}, rbuff5)
+}


### PR DESCRIPTION
Once sh-support and db-support is merged I'll point this PR at main.

+ Adds "echooutput" action that sends last 10kB of PTY output in the DATA-ACK
+ Adds ringbuffer which stores stdout to reflect back to user

## Description of the change

This PR adds the echooutput action to the shell plugin. Echooutput returns the last 10KBs of output from the terminal. 

We use a ringbuffer to store this output.

## Relevant release note information

Adds echooutput action to shell plugin

## Related JIRA tickets

Relates to JIRA: [CWC-1420](https://commonwealthcrypto.atlassian.net/browse/CWC-1420)

## Have you considered the security impacts?

This action a buffered read. Since we already have a streaming read this does not provide the user any additional information and so shouldn't have a security impact. It is just a new way to read the data the user is already getting.

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: