### PR TITLE
fix path join issue

### DIFF
--- a/bzerolib/bzhttp/bzhttp.go
+++ b/bzerolib/bzhttp/bzhttp.go
@@ -34,16 +34,21 @@ func BuildEndpoint(base string, toAdd string) (string, error) {
 	}
 	urlObject.Path = path.Join(urlObject.Path, toAdd)
 
+	// Now undo any url encoding that might have happened in UrlObject.String()
+	decodedUrl, err := url.QueryUnescape(urlObject.String())
+	if err != nil {
+		return "", err
+	}
+
 	// There is a problem with path.Join where it interally calls a Clean(..) function
 	// which will remove any trailing slashes, this causes issues when proxying requests
 	// that are expecting the trailing slash.
 	// Ref: https://forum.golangbridge.org/t/how-to-concatenate-paths-for-api-request/5791
-	toReturn := urlObject.String()
-	if strings.HasSuffix(toAdd, "/") {
-		toReturn += "/"
+	if strings.HasSuffix(toAdd, "/") && !strings.HasSuffix(decodedUrl, "/") {
+		decodedUrl += "/"
 	}
 
-	return toReturn, nil
+	return decodedUrl, nil
 }
 
 // Helper function to extract the body of a http request

--- a/bzerolib/bzhttp/bzhttp.go
+++ b/bzerolib/bzhttp/bzhttp.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"bastionzero.com/bctl/v1/bzerolib/logger"
@@ -32,7 +33,17 @@ func BuildEndpoint(base string, toAdd string) (string, error) {
 		return "", err
 	}
 	urlObject.Path = path.Join(urlObject.Path, toAdd)
-	return urlObject.String(), nil
+
+	// There is a problem with path.Join where it interally calls a Clean(..) function
+	// which will remove any trailing slashes, this causes issues when proxying requests
+	// that are expecting the trailing slash.
+	// Ref: https://forum.golangbridge.org/t/how-to-concatenate-paths-for-api-request/5791
+	toReturn := urlObject.String()
+	if strings.HasSuffix(toAdd, "/") {
+		toReturn += "/"
+	}
+
+	return toReturn, nil
 }
 
 // Helper function to extract the body of a http request

--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -468,7 +468,7 @@ func (w *Websocket) Connect() error {
 	}
 
 	// Make our POST request
-	negotiateEndpoint, err := bzhttp.BuildEndpoint(w.baseUrl, "/negotiate")
+	negotiateEndpoint, err := bzhttp.BuildEndpoint(w.baseUrl, "negotiate")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description of the change

I tried looking around, rewriting the `Clean` function for a bit, but this was the best thing I could come up with and what others have used (see `ref`). It looks like we are actually using the `Clean` function internally for joining Urls: 
![image](https://user-images.githubusercontent.com/28202162/152431779-55d295fc-a3b5-419a-bd40-eb9b181d6df4.png)

So I was unable to just remove that function and create a custom `path.Join` that just does not call `Clean`) 

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: