### PR TITLE
Integrates shell plugin with data channels and agent

### DIFF
--- a/bctl/agent/datachannel/datachannel_test.go
+++ b/bctl/agent/datachannel/datachannel_test.go
@@ -1,0 +1,165 @@
+// Copyright 2022 BastionZero Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may not
+// use this file except in compliance with the License. A copy of the
+// License is located at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package datachannel
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"bastionzero.com/bctl/v1/bctl/agent/keysplitting"
+	am "bastionzero.com/bctl/v1/bzerolib/channels/agentmessage"
+	"bastionzero.com/bctl/v1/bzerolib/channels/websocket"
+	"bastionzero.com/bctl/v1/bzerolib/keysplitting/bzcert"
+	ksmsg "bastionzero.com/bctl/v1/bzerolib/keysplitting/message"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	"bastionzero.com/bctl/v1/bzerolib/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/tomb.v2"
+)
+
+type MocktKeysplitting struct{ keysplitting.Keysplitting }
+
+func (m *MocktKeysplitting) GetHpointer() string                                 { return "fake" }
+func (m *MocktKeysplitting) Validate(ksMessage *ksmsg.KeysplittingMessage) error { return nil }
+func (m *MocktKeysplitting) BuildResponse(ksMessage *ksmsg.KeysplittingMessage,
+	action string,
+	actionPayload []byte) (ksmsg.KeysplittingMessage, error) {
+
+	var responseMessage ksmsg.KeysplittingMessage
+	switch ksMessage.Type {
+	case ksmsg.Syn:
+		responseMessage = ksmsg.KeysplittingMessage{
+			Type:                ksmsg.SynAck,
+			KeysplittingPayload: ksmsg.SynAckPayload{},
+		}
+	case ksmsg.Data:
+		responseMessage = ksmsg.KeysplittingMessage{
+			Type:                ksmsg.DataAck,
+			KeysplittingPayload: ksmsg.DataAckPayload{},
+		}
+	}
+	return responseMessage, nil
+}
+
+type TestWebsocket struct {
+	websocket.Websocket
+	MsgsSent []am.AgentMessage
+}
+
+func (w *TestWebsocket) Connect() {}
+func (w *TestWebsocket) Send(agentMessage am.AgentMessage) {
+	w.MsgsSent = append(w.MsgsSent, agentMessage)
+}
+func (w *TestWebsocket) Unsubscribe(id string)                           {}
+func (w *TestWebsocket) Subscribe(id string, channel websocket.IChannel) {}
+func (w *TestWebsocket) Close(err error)                                 {}
+
+func CreateSynMsg(t *testing.T) []byte {
+	fakebzcert := bzcert.BZCert{}
+	runAsUser := testutils.GetRunAsUser(t)
+	synActionPayload, _ := json.Marshal(bzshell.ShellOpenMessage{RunAsUser: runAsUser})
+
+	synPayload := ksmsg.SynPayload{
+		Timestamp:     fmt.Sprint(time.Now().Unix()),
+		SchemaVersion: ksmsg.SchemaVersion,
+		Type:          string(ksmsg.Syn),
+		Action:        "shell/open",
+		ActionPayload: synActionPayload,
+		TargetId:      "currently unused",
+		Nonce:         "fake nonce",
+		BZCert:        fakebzcert,
+	}
+
+	// var synPayload ksmsg.KeysplittingMessage
+	synBytes, _ := json.Marshal(ksmsg.KeysplittingMessage{
+		Type:                ksmsg.Syn,
+		KeysplittingPayload: synPayload,
+		Signature:           "fake signature",
+	})
+
+	return synBytes
+}
+
+func CreateOpenShellDataMsg() []byte {
+	dataActionPayload, _ := json.Marshal(bzshell.ShellOpenMessage{RunAsUser: "test-user"})
+
+	dataPayload := ksmsg.DataPayload{
+		Timestamp:     fmt.Sprint(time.Now().Unix()),
+		SchemaVersion: ksmsg.SchemaVersion,
+		Type:          string(ksmsg.Data),
+		Action:        "shell/open",
+		ActionPayload: testutils.B64Encode(dataActionPayload),
+		TargetId:      "currently unused",
+		BZCertHash:    "fake",
+	}
+
+	dataBytes, _ := json.Marshal(ksmsg.KeysplittingMessage{
+		Type:                ksmsg.Data,
+		KeysplittingPayload: dataPayload,
+		Signature:           "fake signature",
+	})
+
+	return dataBytes
+}
+
+func CreateAgentMessage(dataBytes []byte) am.AgentMessage {
+	agentMsg := am.AgentMessage{
+		ChannelId:      "fake",
+		MessageType:    "keysplitting",
+		SchemaVersion:  ksmsg.SchemaVersion,
+		MessagePayload: dataBytes,
+	}
+	return agentMsg
+}
+
+func TestShelllDatachannel(t *testing.T) {
+
+	assert.Contains(t, string("abce"), "ab")
+
+	var tmb tomb.Tomb
+	subLogger := testutils.MockLogger()
+	ws := &TestWebsocket{}
+	dcID := "testID-1"
+
+	synBytes := CreateSynMsg(t)
+	datachannel, err := New(&tmb, subLogger, ws, dcID, synBytes, &MocktKeysplitting{})
+
+	assert.NotNil(t, datachannel)
+	assert.Nil(t, err)
+
+	assert.Equal(t, len(ws.MsgsSent), 1)
+	assert.EqualValues(t, "keysplitting", ws.MsgsSent[0].MessageType)
+
+	var synackMsg ksmsg.KeysplittingMessage
+	err = json.Unmarshal(ws.MsgsSent[0].MessagePayload, &synackMsg)
+	assert.Nil(t, err)
+	assert.EqualValues(t, ksmsg.SynAck, synackMsg.Type)
+
+	dataBytes := CreateOpenShellDataMsg()
+	agentMsg := CreateAgentMessage(dataBytes)
+
+	datachannel.processInput(agentMsg)
+
+	assert.Equal(t, len(ws.MsgsSent), 2)
+	assert.EqualValues(t, "keysplitting", ws.MsgsSent[1].MessageType)
+
+	var dataAckMsg ksmsg.KeysplittingMessage
+	err = json.Unmarshal(ws.MsgsSent[1].MessagePayload, &dataAckMsg)
+	assert.Nil(t, err)
+	assert.EqualValues(t, ksmsg.DataAck, dataAckMsg.Type)
+
+}

--- a/bctl/agent/plugin/plugin.go
+++ b/bctl/agent/plugin/plugin.go
@@ -1,5 +1,15 @@
 package plugin
 
+// Plugins this datachannel accepts
+type PluginName string
+
+const (
+	Kube  PluginName = "kube"
+	Db    PluginName = "db"
+	Web   PluginName = "web"
+	Shell PluginName = "shell"
+)
+
 type IPlugin interface {
 	Receive(action string, actionPayload []byte) (string, []byte, error)
 	// Check() bool --> a function that verifies that the plugin can be run in the current environment

--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -45,8 +45,11 @@ const (
 )
 
 type IWebsocket interface {
-	Connect() error
+	Connect()
 	Send(agentMessage am.AgentMessage)
+	Unsubscribe(id string)
+	Subscribe(id string, channel IChannel)
+	Close(error)
 }
 
 // This will be the client that we use to store our websocket connection

--- a/bzerolib/plugin/shell/shell.go
+++ b/bzerolib/plugin/shell/shell.go
@@ -13,7 +13,9 @@
 
 package shell
 
-type ShellOpenMessage struct{}
+type ShellOpenMessage struct {
+	RunAsUser string `json:"runasuser"`
+}
 
 type ShellCloseMessage struct{}
 
@@ -27,10 +29,6 @@ type ShellResizeMessage struct {
 }
 
 type ShellReplayMessage struct{}
-
-type ShellConfigParams struct {
-	RunAsUser string `json:"runasuser"`
-}
 
 type ShellAction string
 

--- a/bzerolib/testutils/testutils.go
+++ b/bzerolib/testutils/testutils.go
@@ -1,0 +1,30 @@
+package testutils
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"bastionzero.com/bctl/v1/bctl/agent/utility"
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+)
+
+func MockLogger() *logger.Logger {
+	logger, err := logger.New(logger.Debug, "/dev/null")
+	if err == nil {
+		return logger
+	}
+	return nil
+}
+
+func B64Encode(b []byte) []byte {
+	// Adds quotes as the base64 encoded strings which receive gets over the data channel has quotes
+	return []byte("\"" + base64.StdEncoding.EncodeToString(b) + "\"")
+}
+
+func GetRunAsUser(t *testing.T) string {
+	username, err := utility.WhoAmI()
+	if err != nil {
+		t.Errorf("Could not resolve username: %v", err)
+	}
+	return username
+}


### PR DESCRIPTION
## Description of the change

This fully integrates the shell plugin into the Agent. To test this functionality this PR adds a simple unittest of the datachannel talking to the agent with keysplitting mocked out.


Additional minor changes include:
 
 * Adds check to see if a plugin is not nil before using it.

 * Refactors plugin enum i.e. plugin name const outside of the datachannel. 

The reason for moving the plugin enum is to avoid a cyclical dependency between the datachannel and the plugin. The datachannel needs to import the plugin, but if the plugin uses a const in the datachannel, the plugin needs to import the datachannel. Thus, moving the const into plugin.go resolves this dependent.


## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: [CWC-1417](https://commonwealthcrypto.atlassian.net/browse/CWC-1417)

## Have you considered the security impacts?

This change makes the shell plugin visible to the agent and allows people to connect to it. Like any new feature it adds attack surface, but it does not add any functionality not already in the our SSM-agent implementation of our protocol

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: