### PR TITLE
Fix/iperf tests

### DIFF
--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -106,6 +106,7 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 		d.closed = true // Ensure that we close the dial action
 
 		// give our streamoutputchan time to process all the messages we sent while the stop request was getting here
+		// CWC-1588: We need to revisit the assumption of one plugin to many actions in order to solve this better
 		time.Sleep(2 * time.Second)
 		return action, actionPayload, nil
 	default:

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"gopkg.in/tomb.v2"
 
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	"bastionzero.com/bctl/v1/bzerolib/plugin/db/actions/dial"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
+)
+
+const (
+	chunkSize = 64 * 1024
 )
 
 type Dial struct {
@@ -54,39 +59,41 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 	switch dial.DialSubAction(action) {
 	case dial.DialStart:
 		var dialActionRequest dial.DialActionPayload
-		if err := json.Unmarshal(actionPayload, &dialActionRequest); err != nil {
+		if err = json.Unmarshal(actionPayload, &dialActionRequest); err != nil {
 			err = fmt.Errorf("malformed dial action payload %v", actionPayload)
 			break
 		}
 
-		return d.startDial(dialActionRequest, action)
+		return d.start(dialActionRequest, action)
 	case dial.DialInput:
-		// Deserialize the action payload, the only action passed is DataIn
-		var dataIn dial.DialInputActionPayload
-		if err := json.Unmarshal(actionPayload, &dataIn); err != nil {
+		// Deserialize the action payload, the only action passed is input
+		var dbInput dial.DialInputActionPayload
+		if err = json.Unmarshal(actionPayload, &dbInput); err != nil {
 			err = fmt.Errorf("unable to unmarshal dial input message: %s", err)
 			break
 		}
 
 		// First validate the requestId
-		if err = d.validateRequestId(dataIn.RequestId); err != nil {
+		if err = d.validateRequestId(dbInput.RequestId); err != nil {
 			break
 		}
 
 		// Then send the data to our remote connection, decode the data first
-		dataToWrite, err := base64.StdEncoding.DecodeString(dataIn.Data)
-		if err != nil {
+		if dataToWrite, nerr := base64.StdEncoding.DecodeString(dbInput.Data); nerr != nil {
+			err = nerr
 			break
+		} else {
+
+			// Send this data to our remote connection
+			d.logger.Info("Received data from daemon, forwarding to remote tcp connection")
+			_, err = d.remoteConnection.Write(dataToWrite)
 		}
 
-		// Send this data to our remote connection
-		d.logger.Info("Received data from bastion, forwarding to remote tcp connection")
-		_, err = d.remoteConnection.Write(dataToWrite)
-	case dial.DialEnd:
+	case dial.DialStop:
 		// Deserialize the action payload, the only action passed is DataIn
 		var dataEnd dial.DialInputActionPayload
-		if err := json.Unmarshal(actionPayload, &dataEnd); err != nil {
-			err = fmt.Errorf("unable to unmarshal dial input message: %s", err)
+		if jerr := json.Unmarshal(actionPayload, &dataEnd); jerr != nil {
+			err = fmt.Errorf("unable to unmarshal dial input message: %s", jerr)
 			break
 		}
 
@@ -95,11 +102,12 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			break
 		}
 
-		// Close the remote connection
-		err = d.remoteConnection.Close()
+		d.remoteConnection.Close()
+		d.closed = true // Ensure that we close the dial action
 
-		// Ensure that we close the dial action
-		d.closed = true
+		// give our streamoutputchan time to process all the messages we sent while the stop request was getting here
+		time.Sleep(2 * time.Second)
+		return action, actionPayload, nil
 	default:
 		err = fmt.Errorf("unhandled stream action: %v", action)
 	}
@@ -110,9 +118,10 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 	return "", []byte{}, err
 }
 
-func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string) (string, []byte, error) {
+func (d *Dial) start(dialActionRequest dial.DialActionPayload, action string) (string, []byte, error) {
 	// Set our requestId
 	d.requestId = dialActionRequest.RequestId
+	d.logger.Infof("Setting request id: %s", d.requestId)
 
 	// For each start, call the dial the TCP address
 	remoteConnection, err := net.DialTCP("tcp", nil, d.remoteAddress)
@@ -121,28 +130,30 @@ func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string
 		return action, []byte{}, err
 	}
 
-	// Setup a go routine to listen for messages coming from this local connection and forward to the client
-	// TODO: Setup tomb for this to be cancelled?
-	sequenceNumber := 1
+	d.remoteConnection = remoteConnection
 
+	// set up a go routine to listen to the tomb dying so that we can interrupt our listening routine
 	go func() {
-		buff := make([]byte, 0xffff)
+		<-d.tmb.Dying()
+		remoteConnection.Close()
+	}()
+
+	// Setup a go routine to listen for messages coming from this local connection and send to daemon
+	go func() {
+		sequenceNumber := 1
+		buff := make([]byte, chunkSize)
+
 		for {
+			// this line blocks until it reads output or error
 			n, err := remoteConnection.Read(buff)
+
 			if err != nil {
 				if err != io.EOF {
-					d.logger.Errorf("Read failed '%s'\n", err)
+					d.logger.Errorf("failed to read from tcp connection: %s", err)
 				}
 
 				// Let our daemon know that we have got the error and we need to close the connection
-				message := smsg.StreamMessage{
-					Type:           string(smsg.DbAgentClose),
-					RequestId:      d.requestId,
-					SequenceNumber: sequenceNumber,
-					Content:        "", // No content for dbAgent Close
-					LogId:          "", // No log id for db messages
-				}
-				d.streamOutputChan <- message
+				d.sendStreamMessage(smsg.DbStreamEnd, sequenceNumber, "")
 
 				// Ensure that we close the dial action
 				d.closed = true
@@ -152,28 +163,29 @@ func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string
 				return
 			}
 
-			tcpBytesBuffer := buff[:n]
-
-			d.logger.Infof("Received %d bytes from local tcp connection, sending to bastion", n)
+			d.logger.Infof("Sending %d bytes from local tcp connection to daemon", n)
 
 			// Now send this to bastion
-			str := base64.StdEncoding.EncodeToString(tcpBytesBuffer)
-			message := smsg.StreamMessage{
-				Type:           string(smsg.DbOut),
-				RequestId:      d.requestId,
-				SequenceNumber: sequenceNumber,
-				Content:        str,
-				LogId:          "", // No log id for db messages
-			}
-			d.streamOutputChan <- message
+			content := base64.StdEncoding.EncodeToString(buff[:n])
+			d.sendStreamMessage(smsg.DbStream, sequenceNumber, content)
 
 			sequenceNumber += 1
 		}
 	}()
 
 	// Update our remote connection
-	d.remoteConnection = remoteConnection
 	return action, []byte{}, nil
+}
+
+func (d *Dial) sendStreamMessage(streamType smsg.StreamType, sequenceNumber int, content string) {
+	message := smsg.StreamMessage{
+		Type:           string(streamType),
+		RequestId:      d.requestId,
+		SequenceNumber: sequenceNumber,
+		Content:        content,
+		LogId:          "", // No log id for db messages
+	}
+	d.streamOutputChan <- message
 }
 
 func (d *Dial) validateRequestId(requestId string) error {

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -87,6 +87,7 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			// Send this data to our remote connection
 			d.logger.Info("Received data from daemon, forwarding to remote tcp connection")
 			_, err = d.remoteConnection.Write(dataToWrite)
+			break
 		}
 
 	case dial.DialStop:

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -82,11 +82,12 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			break
 		}
 
+		d.logger.Infof("BYTES RECV SERVER: %d", len(dataToWrite))
+
 		// Send this data to our remote connection
 		d.logger.Info("Received data from bastion, forwarding to remote tcp connection")
 		_, err = d.remoteConnection.Write(dataToWrite)
 	case dial.DialEnd:
-		d.logger.
 		// Deserialize the action payload, the only action passed is DataIn
 		var dataEnd dial.DialInputActionPayload
 		if err := json.Unmarshal(actionPayload, &dataEnd); err != nil {

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -67,9 +67,6 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			err = fmt.Errorf("unable to unmarshal dial input message: %s", err)
 			break
 		}
-		d.logger.Infof("PASSED REQ ID: %s", dataIn.RequestId)
-		d.logger.Infof("SAVED REQ ID: %s", d.requestId)
-		d.logger.Infof("ACTION: %s", action)
 
 		// First validate the requestId
 		if err = d.validateRequestId(dataIn.RequestId); err != nil {
@@ -82,8 +79,6 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			break
 		}
 
-		d.logger.Infof("BYTES RECV SERVER: %d", len(dataToWrite))
-
 		// Send this data to our remote connection
 		d.logger.Info("Received data from bastion, forwarding to remote tcp connection")
 		_, err = d.remoteConnection.Write(dataToWrite)
@@ -94,9 +89,6 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 			err = fmt.Errorf("unable to unmarshal dial input message: %s", err)
 			break
 		}
-		d.logger.Infof("PASSED REQ ID: %s", dataEnd.RequestId)
-		d.logger.Infof("SAVED REQ ID: %s", d.requestId)
-		d.logger.Infof("ACTION: %s", action)
 
 		// First validate the requestId
 		if err = d.validateRequestId(dataEnd.RequestId); err != nil {
@@ -126,24 +118,6 @@ func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string
 	remoteConnection, err := net.DialTCP("tcp", nil, d.remoteAddress)
 	if err != nil {
 		d.logger.Errorf("Failed to dial remote address: %s", err)
-		// Let our daemon know that we have got the error and we need to close the connection
-		// message := smsg.StreamMessage{
-		// 	Type:           string(smsg.DbAgentClose),
-		// 	RequestId:      d.requestId,
-		// 	SequenceNumber: 0,
-		// 	Content:        "", // No content for dbAgent Close
-		// 	LogId:          "", // No log id for db messages
-		// }
-		// d.logger.Infof("HERE?: %s", d.streamOutputChan)
-		// d.streamOutputChan <- message
-		// d.logger.Infof("AFTER??: %s", d.streamOutputChan)
-
-		// // Ensure that we close the dial action
-		// d.closed = true
-
-		// // Close this connection
-		// // remoteConnection.Close()
-
 		return action, []byte{}, err
 	}
 
@@ -159,7 +133,6 @@ func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string
 				if err != io.EOF {
 					d.logger.Errorf("Read failed '%s'\n", err)
 				}
-				d.logger.Errorf("HERE RCON ERR: %s", err)
 
 				// Let our daemon know that we have got the error and we need to close the connection
 				message := smsg.StreamMessage{

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -191,7 +191,6 @@ func (d *Dial) sendStreamMessage(streamType smsg.StreamType, sequenceNumber int,
 func (d *Dial) validateRequestId(requestId string) error {
 	if requestId != d.requestId {
 		rerr := fmt.Errorf("invalid request ID passed")
-		d.logger.Error(rerr)
 		return rerr
 	}
 	return nil

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -126,7 +126,24 @@ func (d *Dial) startDial(dialActionRequest dial.DialActionPayload, action string
 	remoteConnection, err := net.DialTCP("tcp", nil, d.remoteAddress)
 	if err != nil {
 		d.logger.Errorf("Failed to dial remote address: %s", err)
-		// Let the agent know that there was an error
+		// Let our daemon know that we have got the error and we need to close the connection
+		// message := smsg.StreamMessage{
+		// 	Type:           string(smsg.DbAgentClose),
+		// 	RequestId:      d.requestId,
+		// 	SequenceNumber: 0,
+		// 	Content:        "", // No content for dbAgent Close
+		// 	LogId:          "", // No log id for db messages
+		// }
+		// d.logger.Infof("HERE?: %s", d.streamOutputChan)
+		// d.streamOutputChan <- message
+		// d.logger.Infof("AFTER??: %s", d.streamOutputChan)
+
+		// // Ensure that we close the dial action
+		// d.closed = true
+
+		// // Close this connection
+		// // remoteConnection.Close()
+
 		return action, []byte{}, err
 	}
 

--- a/bctl/agent/plugin/db/db.go
+++ b/bctl/agent/plugin/db/db.go
@@ -11,6 +11,7 @@ import (
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/db/actions/dial"
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	"bastionzero.com/bctl/v1/bzerolib/plugin/db"
+	dial2 "bastionzero.com/bctl/v1/bzerolib/plugin/db/actions/dial"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 	"gopkg.in/tomb.v2"
 )
@@ -135,6 +136,11 @@ func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 			}
 
 			// Send the payload to the action and add it to the map for future incoming requests
+			if action != string(dial2.DialStart) {
+				k.logger.Infof("HERE WHY??? %s", action)
+				rerr := fmt.Errorf("unhandled db action: %v", action)
+				return "", []byte{}, rerr
+			}
 			action, payload, err := a.Receive(action, actionPayloadSafe)
 			return action, payload, err
 		default:

--- a/bctl/agent/plugin/db/db.go
+++ b/bctl/agent/plugin/db/db.go
@@ -11,7 +11,6 @@ import (
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/db/actions/dial"
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	"bastionzero.com/bctl/v1/bzerolib/plugin/db"
-	dial2 "bastionzero.com/bctl/v1/bzerolib/plugin/db/actions/dial"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 	"gopkg.in/tomb.v2"
 )
@@ -135,11 +134,6 @@ func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 			}
 
 			// Send the payload to the action and add it to the map for future incoming requests
-			if action != string(dial2.DialStart) {
-				k.logger.Infof("HERE WHY??? %s", action)
-				rerr := fmt.Errorf("unhandled db action: %v", action)
-				return "", []byte{}, rerr
-			}
 			action, payload, err := a.Receive(action, actionPayloadSafe)
 
 			// The start dial action can cause the action to close initally

--- a/bctl/agent/plugin/db/db.go
+++ b/bctl/agent/plugin/db/db.go
@@ -75,8 +75,8 @@ func New(parentTmb *tomb.Tomb,
 	return plugin, nil
 }
 
-func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte, error) {
-	k.logger.Infof("Plugin received Data message with %v action", action)
+func (d *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte, error) {
+	d.logger.Infof("Plugin received Data message with %v action", action)
 
 	// parse action
 	parsedAction := strings.Split(action, "/")
@@ -95,7 +95,7 @@ func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 	// Json unmarshalling encodes bytes in base64
 	actionPayloadSafe, base64Err := base64.StdEncoding.DecodeString(string(actionPayload))
 	if base64Err != nil {
-		k.logger.Errorf("error decoding actionPayload: %v", base64Err)
+		d.logger.Errorf("error decoding actionPayload: %v", base64Err)
 		return "", []byte{}, base64Err
 	}
 
@@ -109,27 +109,27 @@ func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 	}
 
 	// Lookup if we already started an action for this requestId
-	if act, ok := k.getActionsMap(rid); ok {
+	if act, ok := d.getActionsMap(rid); ok {
 		// If we did, send the payload data to this action
 		action, payload, err := act.Receive(action, actionPayloadSafe)
 
 		// Check if that last message closed the action, if so delete from map
 		if act.Closed() {
-			k.deleteActionsMap(rid)
+			d.deleteActionsMap(rid)
 		}
 
 		return action, payload, err
 	} else {
-		subLogger := k.logger.GetActionLogger(action)
+		subLogger := d.logger.GetActionLogger(action)
 		subLogger.AddRequestId(rid)
 		switch db.DbAction(dbAction) {
 		case db.Dial:
 			// Create a new dbdial action
-			a, err := dial.New(subLogger, k.tmb, k.streamOutputChan, k.remoteAddress)
+			a, err := dial.New(subLogger, d.tmb, d.streamOutputChan, d.remoteAddress)
 
 			if err != nil {
 				rerr := fmt.Errorf("could not start new action object: %s", err)
-				k.logger.Error(rerr)
+				d.logger.Error(rerr)
 				return "", []byte{}, rerr
 			}
 
@@ -139,13 +139,13 @@ func (k *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 			// The start dial action can cause the action to close initally
 			// (i.e. if there is nothing on the other end and we are unable to resolve that tcp addr)
 			if !a.Closed() {
-				k.updateActionsMap(a, rid) // save action for later input
+				d.updateActionsMap(a, rid) // save action for later input
 			}
 
 			return action, payload, err
 		default:
 			rerr := fmt.Errorf("unhandled db action: %v", action)
-			k.logger.Error(rerr)
+			d.logger.Error(rerr)
 			return "", []byte{}, rerr
 		}
 	}

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -83,6 +83,7 @@ func (w *WebDial) Receive(action string, actionPayload []byte) (string, []byte, 
 		w.interruptChan <- true
 
 		// give our streamoutputchan time to process all the messages we sent while the interrupt was getting here
+		// CWC-1588: We need to revisit the assumption of one plugin to many actions in order to solve this better
 		time.Sleep(2 * time.Second)
 
 		// this return payload tells the daemon to close the action on their side

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	chunkSize = 32 * 1024
+	chunkSize = 64 * 1024
 )
 
 type WebDial struct {

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -349,10 +349,13 @@ func (d *DataChannel) processInput(agentMessage am.AgentMessage) error {
 
 func (d *DataChannel) handleError(agentMessage am.AgentMessage) error {
 	var errMessage rrr.ErrorMessage
+	d.logger.Infof("HERE ERROR: %v", errMessage)
 	if err := json.Unmarshal(agentMessage.MessagePayload, &errMessage); err != nil {
+		d.logger.Infof("MALFORMED?")
 		return fmt.Errorf("malformed Error message")
 	} else {
 		rerr := fmt.Errorf("received error from agent: %s", errMessage.Message)
+		d.logger.Infof("HERE ERROR: %v", errMessage)
 
 		// Keysplitting validation errors are probably going to be mostly bzcert renewals and
 		// we don't want to break every time that happens so we need to get back on the ks train
@@ -367,9 +370,11 @@ func (d *DataChannel) handleError(agentMessage am.AgentMessage) error {
 			// In order to get back on the keysplitting train, we need to resend the syn, get the synack
 			// so that our input message handler is pointing to the right thing.
 			if err := d.sendSyn(d.getOnDeck().Action); err != nil {
+				d.logger.Infof("HERE ERROR: %s - %v", err, errMessage)
 				return err
 			}
 		} else {
+			d.logger.Infof("HERE ERROR CLOSE?")
 			d.Close(rerr)
 		}
 

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -349,13 +349,10 @@ func (d *DataChannel) processInput(agentMessage am.AgentMessage) error {
 
 func (d *DataChannel) handleError(agentMessage am.AgentMessage) error {
 	var errMessage rrr.ErrorMessage
-	d.logger.Infof("HERE ERROR: %v", errMessage)
 	if err := json.Unmarshal(agentMessage.MessagePayload, &errMessage); err != nil {
-		d.logger.Infof("MALFORMED?")
 		return fmt.Errorf("malformed Error message")
 	} else {
 		rerr := fmt.Errorf("received error from agent: %s", errMessage.Message)
-		d.logger.Infof("HERE ERROR: %v", errMessage)
 
 		// Keysplitting validation errors are probably going to be mostly bzcert renewals and
 		// we don't want to break every time that happens so we need to get back on the ks train
@@ -370,15 +367,11 @@ func (d *DataChannel) handleError(agentMessage am.AgentMessage) error {
 			// In order to get back on the keysplitting train, we need to resend the syn, get the synack
 			// so that our input message handler is pointing to the right thing.
 			if err := d.sendSyn(d.getOnDeck().Action); err != nil {
-				d.logger.Infof("HERE ERROR: %s - %v", err, errMessage)
 				return err
 			}
 		} else {
-			d.logger.Infof("HERE ERROR CLOSE?")
 			d.Close(rerr)
 		}
-
-		d.logger.Infof("HERE ERROR: %s - %v", rerr, errMessage)
 
 		return rerr
 	}

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -373,6 +373,8 @@ func (d *DataChannel) handleError(agentMessage am.AgentMessage) error {
 			d.Close(rerr)
 		}
 
+		d.logger.Infof("HERE ERROR: %s - %v", rerr, errMessage)
+
 		return rerr
 	}
 }

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -72,7 +72,6 @@ func (s *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 			case data := <-s.streamInputChan:
 				switch smsg.StreamType(data.Type) {
 				case smsg.DbOut:
-					s.logger.Infof("SEQ NUMBER: %d", data.SequenceNumber)
 					contentBytes, _ := base64.StdEncoding.DecodeString(data.Content)
 
 					_, err := lconn.Write(contentBytes)
@@ -82,7 +81,7 @@ func (s *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 				case smsg.DbAgentClose:
 					// The agent has closed the connection, close the local connection as well
 					s.logger.Info("remote tcp connection has been closed, closing local tcp connection")
-					if close != true {
+					if !close {
 						lconn.Close()
 						close = true
 					}
@@ -127,8 +126,6 @@ func (s *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 		}
 
 		buff := tmp[:n]
-
-		s.logger.Infof("BYTES RECV CLIENT: %d", len(buff))
 
 		dataToSend := base64.StdEncoding.EncodeToString(buff)
 

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -14,6 +14,10 @@ import (
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 )
 
+const (
+	chunkSize = 64 * 1024
+)
+
 type DialAction struct {
 	logger    *logger.Logger
 	requestId string
@@ -24,8 +28,8 @@ type DialAction struct {
 
 	closed bool
 
-	sequenceNumber  int
-	localConnection *net.TCPConn
+	// this channel lets us communicate between our agent listener and our local tcp conn listener
+	doneChan chan bool
 }
 
 func New(logger *logger.Logger,
@@ -38,121 +42,112 @@ func New(logger *logger.Logger,
 		outputChan:      make(chan plugin.ActionWrapper, 10),
 		streamInputChan: make(chan smsg.StreamMessage, 10),
 
-		sequenceNumber: 0,
+		doneChan: make(chan bool),
 	}
 
 	return stream, stream.outputChan
 }
 
-func (s *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
-	// this action ends at the end of this function, in order to signal that to the parent plugin,
-	// we close the output channel which will close the go routine listening on it
-	defer close(s.outputChan)
-	close := false
+func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 
-	// Set our local connection
-	s.localConnection = lconn
-
-	// Build the action payload
+	// Build and send the action payload to start the tcp connection on the agent
 	payload := dial.DialActionPayload{
-		RequestId: s.requestId,
+		RequestId: d.requestId,
 	}
+	d.sendOutputMessage(dial.DialStart, payload)
 
-	// Send payload to plugin output queue
-	payloadBytes, _ := json.Marshal(payload)
-	s.outputChan <- plugin.ActionWrapper{
-		Action:        string(dial.DialStart),
-		ActionPayload: payloadBytes,
-	}
-
-	// Listen to stream messages coming from bastion, and forward to our local connection
+	// Listen to stream messages coming from the agent, and forward to our local connection
 	go func() {
+		defer lconn.Close()
+
 		for {
 			select {
-			case data := <-s.streamInputChan:
+			case <-tmb.Dying():
+				return
+			case <-d.doneChan:
+				return
+			case data := <-d.streamInputChan:
 				switch smsg.StreamType(data.Type) {
-				case smsg.DbOut:
-					contentBytes, _ := base64.StdEncoding.DecodeString(data.Content)
 
-					_, err := lconn.Write(contentBytes)
-					if err != nil {
-						s.logger.Errorf("write failed: %s", err)
+				case smsg.DbStream:
+					if contentBytes, err := base64.StdEncoding.DecodeString(data.Content); err != nil {
+						d.logger.Errorf("could not decode db stream content: %s", err)
+					} else if _, err := lconn.Write(contentBytes); err != nil {
+						d.logger.Errorf("failed to write to local tcp connection: %s", err)
 					}
-				case smsg.DbAgentClose:
+
+				case smsg.DbStreamEnd:
+
 					// The agent has closed the connection, close the local connection as well
-					s.logger.Info("remote tcp connection has been closed, closing local tcp connection")
-					if !close {
-						lconn.Close()
-						close = true
-					}
-
+					d.logger.Info("remote tcp connection has been closed, closing local tcp connection")
+					d.closed = true
 					return
+
 				default:
-					s.logger.Errorf("unhandled stream type: %s", data.Type)
+					d.logger.Errorf("unhandled stream type: %s", data.Type)
 				}
 			}
 		}
 	}()
 
-	// Keep looping till we hit EOF
-	tmp := make([]byte, 0xffff)
+	// listen to messages coming from the local tcp connection and sends them to the agent
+	buf := make([]byte, chunkSize)
+	sequenceNumber := 0
+
 	for {
-		n, err := lconn.Read(tmp)
-		if err == io.EOF {
-			// Tell the agent to stop the dial session
-			s.logger.Info("local tcp connection has been closed")
-
-			if !close {
-				// Build the action payload
-				payload := dial.DialActionPayload{
-					RequestId: s.requestId,
-				}
-
-				// Send payload to plugin output queue
-				payloadBytes, _ := json.Marshal(payload)
-				s.outputChan <- plugin.ActionWrapper{
-					Action:        string(dial.DialEnd),
-					ActionPayload: payloadBytes,
-				}
-				lconn.Close()
+		if n, err := lconn.Read(buf); err != nil {
+			// print our error message
+			if err == io.EOF {
+				d.logger.Info("local tcp connection has been closed")
+			} else {
+				d.logger.Errorf("error reading from local tcp connection: %s", err)
 			}
 
-			return nil
+			// let the agent know we need to stop
+			payload := dial.DialActionPayload{
+				RequestId: d.requestId,
+			}
+			d.sendOutputMessage(dial.DialStop, payload)
+
+			// tell our agent message listener to stop processing incoming stream messages
+			d.doneChan <- true
+			break
+		} else {
+			// Build and send whatever we get from the local tcp connection to the agent
+			dataToSend := base64.StdEncoding.EncodeToString(buf[:n])
+			payload := dial.DialInputActionPayload{
+				RequestId:      d.requestId,
+				SequenceNumber: sequenceNumber,
+				Data:           dataToSend,
+			}
+			d.sendOutputMessage(dial.DialInput, payload)
+
+			sequenceNumber += 1
 		}
-		if err != nil {
-			s.logger.Errorf("Read failed '%s'\n", err)
-			// Tell the agent to stop the dial session
-			return nil
-		}
+	}
 
-		buff := tmp[:n]
+	return nil
+}
 
-		dataToSend := base64.StdEncoding.EncodeToString(buff)
-
-		// Build the action payload
-		payload := dial.DialInputActionPayload{
-			RequestId:      s.requestId,
-			SequenceNumber: s.sequenceNumber,
-			Data:           dataToSend,
-		}
-
-		// Send payload to plugin output queue
-		payloadBytes, _ := json.Marshal(payload)
-		s.outputChan <- plugin.ActionWrapper{
-			Action:        string(dial.DialInput),
-			ActionPayload: payloadBytes,
-		}
-
-		s.sequenceNumber += 1
+func (d *DialAction) sendOutputMessage(action dial.DialSubAction, payload interface{}) {
+	// Send payload to plugin output queue
+	payloadBytes, _ := json.Marshal(payload)
+	d.outputChan <- plugin.ActionWrapper{
+		Action:        string(action),
+		ActionPayload: payloadBytes,
 	}
 
 }
 
-func (s *DialAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) {
-	// We do not need to receive any keysplitting messages
+func (d *DialAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) {
+	if wrappedAction.Action == string(dial.DialStop) {
+
+		// this signals to the parent plugin that we're done with the action
+		close(d.outputChan)
+	}
 }
 
-func (s *DialAction) ReceiveStream(smessage smsg.StreamMessage) {
-	s.logger.Debugf("Stream action received %v stream", smessage.Type)
-	s.streamInputChan <- smessage
+func (d *DialAction) ReceiveStream(smessage smsg.StreamMessage) {
+	d.logger.Debugf("Stream action received %v stream", smessage.Type)
+	d.streamInputChan <- smessage
 }

--- a/bctl/daemon/plugin/db/db.go
+++ b/bctl/daemon/plugin/db/db.go
@@ -116,8 +116,8 @@ func (k *DbDaemonPlugin) processKeysplitting(action string, actionPayload []byte
 	}
 
 	// No keysplitting data comes from dial plugins on the agent
-	k.logger.Errorf("keysplitting message received. This should not happen")
-	return nil
+	err := fmt.Errorf("keysplitting message received. This should not happen")
+	return err
 }
 
 func (k *DbDaemonPlugin) Feed(food interface{}) error {

--- a/bctl/daemon/servers/dbserver/dbserver.go
+++ b/bctl/daemon/servers/dbserver/dbserver.go
@@ -121,6 +121,7 @@ func StartDbServer(logger *logger.Logger,
 		// Always generate a requestId, each new proxy connection is its own request
 		requestId := uuid.New().String()
 
+		logger.Infof("Accepting new tcp connection")
 		go listener.handleProxy(conn, logger, requestId)
 	}
 }

--- a/bctl/daemon/servers/dbserver/dbserver.go
+++ b/bctl/daemon/servers/dbserver/dbserver.go
@@ -121,7 +121,6 @@ func StartDbServer(logger *logger.Logger,
 			} else {
 				logger.Errorf("error starting datachannel: %s", err)
 			}
-			// go listener.handleProxy(conn, logger)
 		}()
 
 	}

--- a/bzerolib/plugin/db/actions/dial/dial.go
+++ b/bzerolib/plugin/db/actions/dial/dial.go
@@ -5,7 +5,7 @@ type DialSubAction string
 const (
 	DialStart DialSubAction = "db/dial/start"
 	DialInput DialSubAction = "db/dial/input"
-	DialEnd   DialSubAction = "db/dial/end"
+	DialStop  DialSubAction = "db/dial/stop"
 )
 
 type DialActionPayload struct {

--- a/bzerolib/plugin/db/actions/dial/dial.go
+++ b/bzerolib/plugin/db/actions/dial/dial.go
@@ -5,6 +5,7 @@ type DialSubAction string
 const (
 	DialStart DialSubAction = "db/dial/start"
 	DialInput DialSubAction = "db/dial/input"
+	DialEnd   DialSubAction = "db/dial/end"
 )
 
 type DialActionPayload struct {

--- a/bzerolib/stream/message/stream.go
+++ b/bzerolib/stream/message/stream.go
@@ -25,8 +25,8 @@ const (
 	PortForwardData  StreamType = "kube/portforward/data"
 	PortForwardError StreamType = "kube/portforward/error"
 
-	DbOut        StreamType = "db/dataout"
-	DbAgentClose StreamType = "db/agentClose"
+	DbStream    StreamType = "db/stream"
+	DbStreamEnd StreamType = "db/stream/end"
 
 	WebError     StreamType = "web/error"
 	WebStream    StreamType = "web/stream"


### PR DESCRIPTION
## Description of the change

This PR fixes the issue of iperf tests by ensuring that each TCP connection gets its own data channel. This also catches other minor issues such as:
* The bidirectional ability to close TCP connections
* minor logging issues

```
➜  bzero git:(fix/iperf-tests) iperf3 -c localhost -p 6101 -i 10 -t 60 -V 
iperf 3.11
Darwin Sids-MacBook-Pro.local 21.2.0 Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:41 PST 2021; root:xnu-8019.61.5~1/RELEASE_ARM64_T6000 arm64
Control connection MSS 16332
Time: Thu, 10 Mar 2022 17:14:41 UTC
Connecting to host localhost, port 6101
      Cookie: bgndge2e4treuyzok5l72ref7xc3rvh3hpie
      TCP MSS: 16332 (default)
[  9] local 127.0.0.1 port 53965 connected to 127.0.0.1 port 6101
Starting Test: protocol: TCP, 1 streams, 131072 byte blocks, omitting 0 seconds, 60 second test, tos 0



[ ID] Interval           Transfer     Bitrate
[  9]   0.00-10.01  sec  7.98 MBytes  6.69 Mbits/sec                  
[  9]  10.01-20.01  sec  3.93 MBytes  3.29 Mbits/sec                  
[  9]  20.01-30.01  sec  4.33 MBytes  3.63 Mbits/sec                  
[  9]  30.01-40.01  sec  3.76 MBytes  3.15 Mbits/sec                  
[  9]  40.01-50.01  sec  4.37 MBytes  3.67 Mbits/sec                  
[  9]  50.01-60.00  sec  4.37 MBytes  3.66 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
Test Complete. Summary Results:
[ ID] Interval           Transfer     Bitrate
[  9]   0.00-60.00  sec  28.7 MBytes  4.02 Mbits/sec                  sender
[  9]   0.00-60.00  sec  24.7 MBytes  3.45 Mbits/sec                  receiver
CPU Utilization: local/sender 1.1% (0.3%u/0.8%s), remote/receiver 0.0% (0.0%u/0.0%s)

iperf Done.
```

## Relevant release note information

Release Notes: Fix DB daemon to allow for iperf tests

## Related JIRA tickets

Relates to JIRA: CWC-1586

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [X] No

If yes, please explain: