### PR TITLE
Fix/web stream chunking

### DIFF
--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -208,6 +208,7 @@ func (d *DataChannel) handleKeysplittingMessage(keysplittingMessage *ksmsg.Keysp
 		dataPayload := keysplittingMessage.KeysplittingPayload.(ksmsg.DataPayload)
 
 		// Send message to plugin and catch response action payload
+		// TODO: if we're ignoring the action we should really not be sending it up here
 		if _, returnPayload, err := d.plugin.Receive(dataPayload.Action, dataPayload.ActionPayload); err == nil {
 
 			// Build and send response

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -190,34 +190,31 @@ func (w *WebDial) HandleNewHttpRequest(action string, dataIn WebInputActionPaylo
 						w.sendWebDataStreamMessage(&responsePayload, sequenceNumber, smsg.WebError)
 					}
 
-					// if we've got something to send, send it
-					if numBytes > 0 {
-						w.logger.Debugf("Building response for chunk #%d of size %d", sequenceNumber, numBytes)
+					w.logger.Debugf("Building response for chunk #%d of size %d", sequenceNumber, numBytes)
 
-						// Now we need to send that data back to the client
-						responsePayload = WebOutputActionPayload{
-							StatusCode: res.StatusCode,
-							RequestId:  dataIn.RequestId,
-							Headers:    header,
-							Content:    buf[:numBytes],
-						}
-
-						// if we got an io.EOF, this is the final message so let the daemon know
-						streamMessage := smsg.WebStream
-						if err == io.EOF {
-							streamMessage = smsg.WebStreamEnd
-						}
-
-						w.sendWebDataStreamMessage(&responsePayload, sequenceNumber, streamMessage)
+					// Now we need to send that data back to the client
+					responsePayload = WebOutputActionPayload{
+						StatusCode: res.StatusCode,
+						RequestId:  dataIn.RequestId,
+						Headers:    header,
+						Content:    buf[:numBytes],
 					}
 
-					// we get io.EOFs on whichever read call processes the final byte
+					// if we got an io.EOF, this is the final message so let the daemon know
+					streamMessage := smsg.WebStream
 					if err == io.EOF {
-						break
+						streamMessage = smsg.WebStreamEnd
 					}
 
-					sequenceNumber += 1
+					w.sendWebDataStreamMessage(&responsePayload, sequenceNumber, streamMessage)
 				}
+
+				// we get io.EOFs on whichever read call processes the final byte
+				if err == io.EOF {
+					break
+				}
+
+				sequenceNumber += 1
 			}
 		}()
 	}

--- a/bctl/agent/plugin/web/web.go
+++ b/bctl/agent/plugin/web/web.go
@@ -47,7 +47,7 @@ func New(parentTmb *tomb.Tomb,
 	// Unmarshal the Syn payload
 	var actionPayload bzweb.WebActionParams
 	if err := json.Unmarshal(payload, &actionPayload); err != nil {
-		return nil, fmt.Errorf("malformed Db plugin SYN payload %v", string(payload))
+		return nil, fmt.Errorf("malformed web plugin SYN payload %v", string(payload))
 	}
 
 	plugin := &WebPlugin{
@@ -82,7 +82,7 @@ func (k *WebPlugin) Receive(action string, actionPayload []byte) (string, []byte
 	// Json unmarshalling encodes bytes in base64
 	actionPayloadSafe, base64Err := base64.StdEncoding.DecodeString(string(actionPayload))
 	if base64Err != nil {
-		k.logger.Errorf("error decoding actionPayload: %v", base64Err)
+		k.logger.Errorf("error decoding actionPayload: %s", base64Err)
 		return "", []byte{}, base64Err
 	}
 
@@ -90,7 +90,7 @@ func (k *WebPlugin) Receive(action string, actionPayload []byte) (string, []byte
 	var justrid JustRequestId
 	var rid string
 	if err := json.Unmarshal(actionPayloadSafe, &justrid); err != nil {
-		return "", []byte{}, fmt.Errorf("could not unmarshal json: %v", err.Error())
+		return "", []byte{}, fmt.Errorf("could not unmarshal json: %s, payload: %s", err, string(actionPayloadSafe))
 	} else {
 		rid = justrid.RequestId
 	}

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -114,13 +114,15 @@ func (k *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byt
 }
 
 func (w *WebDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
-	w.logger.Infof("action received at web plugin: %s", action)
 
+	// we only care about a single action right now
 	if action == string(bzwebdial.WebDialInterrupt) {
 		var webInterrupt bzwebdial.WebInterruptActionPayload
 		if err := json.Unmarshal(actionPayload, &webInterrupt); err != nil {
 			return fmt.Errorf("could not unmarshal json: %s", err)
 		} else {
+
+			// push the keysplitting message to the action
 			if act, ok := w.getActionsMap(webInterrupt.RequestId); ok {
 				act.ReceiveKeysplitting(plugin.ActionWrapper{
 					Action:        action,
@@ -130,13 +132,6 @@ func (w *WebDaemonPlugin) processKeysplitting(action string, actionPayload []byt
 			}
 		}
 	}
-	// if actionPayload is empty, then there's nothing we need to process
-	if len(actionPayload) == 0 {
-		return nil
-	}
-
-	// No keysplitting data comes from dial plugins on the agent
-	w.logger.Errorf("keysplitting message received. This should not happen")
 	return nil
 }
 

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -14,6 +14,7 @@ import (
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	"bastionzero.com/bctl/v1/bzerolib/plugin"
 	bzweb "bastionzero.com/bctl/v1/bzerolib/plugin/web"
+	bzwebdial "bastionzero.com/bctl/v1/bzerolib/plugin/web/actions/webdial"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 )
 
@@ -81,7 +82,7 @@ func (k *WebDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
 		return nil
 	}
 
-	rerr := fmt.Errorf("unknown request ID: %v. This is expected if the action has already been compleated", smessage.RequestId)
+	rerr := fmt.Errorf("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
 	k.logger.Error(rerr)
 	return rerr
 }
@@ -112,18 +113,34 @@ func (k *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byt
 	}
 }
 
-func (k *WebDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
+func (w *WebDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
+	w.logger.Infof("action received at web plugin: %s", action)
+
+	if action == string(bzwebdial.WebDialInterrupt) {
+		var webInterrupt bzwebdial.WebInterruptActionPayload
+		if err := json.Unmarshal(actionPayload, &webInterrupt); err != nil {
+			return fmt.Errorf("could not unmarshal json: %s", err)
+		} else {
+			if act, ok := w.getActionsMap(webInterrupt.RequestId); ok {
+				act.ReceiveKeysplitting(plugin.ActionWrapper{
+					Action:        action,
+					ActionPayload: actionPayload,
+				})
+				return nil
+			}
+		}
+	}
 	// if actionPayload is empty, then there's nothing we need to process
 	if len(actionPayload) == 0 {
 		return nil
 	}
 
 	// No keysplitting data comes from dial plugins on the agent
-	k.logger.Errorf("keysplitting message received. This should not happen")
+	w.logger.Errorf("keysplitting message received. This should not happen")
 	return nil
 }
 
-func (k *WebDaemonPlugin) Feed(food interface{}) error {
+func (w *WebDaemonPlugin) Feed(food interface{}) error {
 	// Make sure food matches what it says on the label
 	webFood, ok := food.(bzweb.WebFood)
 	if !ok {
@@ -133,7 +150,7 @@ func (k *WebDaemonPlugin) Feed(food interface{}) error {
 	requestId := uuid.New().String()
 
 	// Create action logger
-	actLogger := k.logger.GetActionLogger(string(webFood.Action))
+	actLogger := w.logger.GetActionLogger(string(webFood.Action))
 	actLogger.AddRequestId(requestId)
 
 	var act IWebDaemonAction
@@ -146,35 +163,35 @@ func (k *WebDaemonPlugin) Feed(food interface{}) error {
 		act, actOutputChan = webwebsocket.New(actLogger, requestId)
 	default:
 		rerr := fmt.Errorf("unrecognized web action: %v", string(webFood.Action))
-		k.logger.Error(rerr)
+		w.logger.Error(rerr)
 		return rerr
 	}
 
 	// add the action to the action map for future interaction
-	k.updateActionsMap(act, requestId)
+	w.updateActionsMap(act, requestId)
 
 	// listen to action output channel, remove action from map if channel is closed
 	go func() {
 		for {
 			select {
-			case <-k.tmb.Dying():
+			case <-w.tmb.Dying():
 				return
 			case m, more := <-actOutputChan:
 				if more {
-					k.outputQueue <- m
+					w.outputQueue <- m
 				} else {
-					k.deleteActionsMap(requestId)
+					w.deleteActionsMap(requestId)
 					return
 				}
 			}
 		}
 	}()
 
-	k.logger.Infof("Created %s action with requestId %v", string(webFood.Action), requestId)
+	w.logger.Infof("Created %s action with requestId %v", string(webFood.Action), requestId)
 
 	// send local tcp connection to action
-	if err := act.Start(k.tmb, webFood.Writer, webFood.Request); err != nil {
-		k.logger.Error(fmt.Errorf("%s error: %s", string(webFood.Action), err))
+	if err := act.Start(w.tmb, webFood.Writer, webFood.Request); err != nil {
+		w.logger.Error(fmt.Errorf("%s error: %s", string(webFood.Action), err))
 	}
 
 	return nil

--- a/bzerolib/plugin/web/actions/webdial/webdial.go
+++ b/bzerolib/plugin/web/actions/webdial/webdial.go
@@ -1,5 +1,13 @@
 package webdial
 
+type WebDialSubAction string
+
+const (
+	WebDialStart     WebDialSubAction = "web/dial/start"
+	WebDialInput     WebDialSubAction = "web/dial/datain"
+	WebDialInterrupt WebDialSubAction = "web/dial/interrupt"
+)
+
 type WebDialActionPayload struct {
 	RequestId string `json:"requestId"`
 }

--- a/bzerolib/stream/message/stream.go
+++ b/bzerolib/stream/message/stream.go
@@ -28,7 +28,9 @@ const (
 	DbOut        StreamType = "db/dataout"
 	DbAgentClose StreamType = "db/agentClose"
 
-	WebOut StreamType = "web/dataout"
+	WebError     StreamType = "web/error"
+	WebStream    StreamType = "web/stream"
+	WebStreamEnd StreamType = "web/stream/end"
 
 	StreamData  StreamType = "kube/stream/stdout"
 	StreamStart StreamType = "kube/stream/start"


### PR DESCRIPTION
## Description of the change

Downloading large files in the agent results in the memory segmentation fault which crashes the agent.  This PR introduces chunking the http response which makes it easier for both the agent and the daemon to process such messages.  In addition, we've needed to add interrupt functionality so that when someone CTRL+C during a download, the daemon doesn't continue to download that file.

PR also includes small wording fixes.

*Comparative Speed Tests*
Bzero: ~24 Mbps (~5 minutes to download 1GB file)
SSH: 48-64 Mbps (~2.5 minutes to download 1GB file)
SSH via SSM: ~5.5 Mbps

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1534

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: