### PR TITLE
Fix/db write fixes

### DIFF
--- a/bctl/agent/controlchannel/controlchannel.go
+++ b/bctl/agent/controlchannel/controlchannel.go
@@ -247,7 +247,7 @@ func (c *ControlChannel) processInput(agentMessage am.AgentMessage) error {
 					return fmt.Errorf("agent does not have a datachannel with id: %s", cdRequest.DataChannelId)
 				}
 			} else {
-				return fmt.Errorf("agent does not have a websocket with id: %s", cdRequest.ConnectionId)
+				return fmt.Errorf("agent does not have a datachannel with id: %s", cdRequest.DataChannelId)
 			}
 		}
 	default:

--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -227,7 +227,7 @@ func (d *DataChannel) startPlugin(pluginName PluginName, payload []byte) error {
 	d.logger.Infof("Starting %v plugin", pluginName)
 
 	// create channel and listener and pass it to the new plugin
-	streamOutputChan := make(chan smsg.StreamMessage, 20)
+	streamOutputChan := make(chan smsg.StreamMessage, 30)
 	go func() {
 		for {
 			select {

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -109,7 +109,6 @@ func (d *Dial) Receive(action string, actionPayload []byte) (string, []byte, err
 
 		// give our streamoutputchan time to process all the messages we sent while the stop request was getting here
 		time.Sleep(5 * time.Second)
-		d.logger.Debugf("GOT HERE: %+v", dataEnd)
 		return action, actionPayload, nil
 	default:
 		err = fmt.Errorf("unhandled stream action: %v", action)

--- a/bctl/agent/plugin/db/db.go
+++ b/bctl/agent/plugin/db/db.go
@@ -76,7 +76,8 @@ func New(parentTmb *tomb.Tomb,
 }
 
 func (d *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte, error) {
-	d.logger.Infof("Plugin received Data message with %v action", action)
+	d.logger.Infof("DB plugin received Data message with %v action", action)
+	d.logger.Infof("actionPayload: %s", string(actionPayload))
 
 	// parse action
 	parsedAction := strings.Split(action, "/")
@@ -115,6 +116,7 @@ func (d *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 
 		// Check if that last message closed the action, if so delete from map
 		if act.Closed() {
+			d.logger.Infof("ACTION CLOSED. DELETING")
 			d.deleteActionsMap(rid)
 		}
 

--- a/bctl/agent/plugin/db/db.go
+++ b/bctl/agent/plugin/db/db.go
@@ -116,7 +116,7 @@ func (d *DbPlugin) Receive(action string, actionPayload []byte) (string, []byte,
 
 		// Check if that last message closed the action, if so delete from map
 		if act.Closed() {
-			d.logger.Infof("ACTION CLOSED. DELETING")
+			d.logger.Infof("Action closed. request id: %s", rid)
 			d.deleteActionsMap(rid)
 		}
 

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -176,8 +176,6 @@ func (w *WebDial) HandleNewHttpRequest(action string, dataIn WebInputActionPaylo
 					// ref: https://go.dev/src/net/http/response.go
 					numBytes, err := res.Body.Read(buf)
 
-					w.logger.Infof("%s", err)
-
 					// check for error and if it's serious then report it
 					if err != nil && err != io.EOF {
 						w.logger.Errorf("error reading response body: %s", err)

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -176,6 +176,8 @@ func (w *WebDial) HandleNewHttpRequest(action string, dataIn WebInputActionPaylo
 					// ref: https://go.dev/src/net/http/response.go
 					numBytes, err := res.Body.Read(buf)
 
+					w.logger.Infof("%s", err)
+
 					// check for error and if it's serious then report it
 					if err != nil && err != io.EOF {
 						w.logger.Errorf("error reading response body: %s", err)
@@ -208,14 +210,14 @@ func (w *WebDial) HandleNewHttpRequest(action string, dataIn WebInputActionPaylo
 					}
 
 					w.sendWebDataStreamMessage(&responsePayload, sequenceNumber, streamMessage)
-				}
 
-				// we get io.EOFs on whichever read call processes the final byte
-				if err == io.EOF {
-					break
-				}
+					// we get io.EOFs on whichever read call processes the final byte
+					if err == io.EOF {
+						return
+					}
 
-				sequenceNumber += 1
+					sequenceNumber += 1
+				}
 			}
 		}()
 	}

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -438,6 +438,11 @@ func (d *DataChannel) handleKeysplitting(agentMessage am.AgentMessage) error {
 	// Send message to plugin's input message handler
 	if d.plugin != nil {
 		if action, returnPayload, err := d.plugin.ReceiveKeysplitting(action, actionResponsePayload); err == nil {
+			// sometimes when we kill the datachannel from the action, there is a final empty payload that sneaks out because
+			// the process dies but that last messages are processed
+			if action == "" {
+				return nil
+			}
 
 			// We need to know the last message for invisible response to keysplitting validation errors
 			d.setLastMessage(bzplugin.ActionWrapper{

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -3,8 +3,10 @@ package dial
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net"
+	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -20,6 +22,7 @@ const (
 
 type DialAction struct {
 	logger    *logger.Logger
+	tmb       *tomb.Tomb
 	requestId string
 
 	// input and output channels relative to this plugin
@@ -27,9 +30,6 @@ type DialAction struct {
 	streamInputChan chan smsg.StreamMessage
 
 	closed bool
-
-	// this channel lets us communicate between our agent listener and our local tcp conn listener
-	doneChan chan bool
 }
 
 func New(logger *logger.Logger,
@@ -40,15 +40,14 @@ func New(logger *logger.Logger,
 		requestId: requestId,
 
 		outputChan:      make(chan plugin.ActionWrapper, 10),
-		streamInputChan: make(chan smsg.StreamMessage, 10),
-
-		doneChan: make(chan bool),
+		streamInputChan: make(chan smsg.StreamMessage, 30),
 	}
 
 	return stream, stream.outputChan
 }
 
 func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
+	d.tmb = tmb
 
 	// Build and send the action payload to start the tcp connection on the agent
 	payload := dial.DialActionPayload{
@@ -58,31 +57,33 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 
 	// Listen to stream messages coming from the agent, and forward to our local connection
 	go func() {
-		defer lconn.Close()
-
 		for {
 			select {
 			case <-tmb.Dying():
 				return
-			case <-d.doneChan:
-				return
 			case data := <-d.streamInputChan:
-				switch smsg.StreamType(data.Type) {
+				if d.closed {
+					continue
+				}
 
+				switch smsg.StreamType(data.Type) {
 				case smsg.DbStream:
 					if contentBytes, err := base64.StdEncoding.DecodeString(data.Content); err != nil {
 						d.logger.Errorf("could not decode db stream content: %s", err)
-					} else if _, err := lconn.Write(contentBytes); err != nil {
-						d.logger.Errorf("failed to write to local tcp connection: %s", err)
+					} else {
+						go func() {
+							time.Sleep(time.Millisecond)
+							lconn.Write(contentBytes) // did you know this blocks forever if you write too fast to it? yeah.
+						}()
 					}
-
 				case smsg.DbStreamEnd:
 
 					// The agent has closed the connection, close the local connection as well
 					d.logger.Info("remote tcp connection has been closed, closing local tcp connection")
-					d.closed = true
-					return
+					d.closeAction()
+					lconn.Close()
 
+					return
 				default:
 					d.logger.Errorf("unhandled stream type: %s", data.Type)
 				}
@@ -90,41 +91,50 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 		}
 	}()
 
-	// listen to messages coming from the local tcp connection and sends them to the agent
-	buf := make([]byte, chunkSize)
-	sequenceNumber := 0
+	go func() {
+		defer lconn.Close()
 
-	for {
-		if n, err := lconn.Read(buf); err != nil {
-			// print our error message
-			if err == io.EOF {
-				d.logger.Info("local tcp connection has been closed")
+		// listen to messages coming from the local tcp connection and sends them to the agent
+		buf := make([]byte, chunkSize)
+		sequenceNumber := 0
+
+		for {
+			if n, err := lconn.Read(buf); err != nil {
+				if d.closed {
+					break
+				}
+
+				// print our error message
+				if err == io.EOF {
+					d.logger.Info("local tcp connection has been closed")
+				} else {
+					d.logger.Errorf("error reading from local tcp connection: %s", err)
+				}
+
+				// let the agent know we need to stop
+				payload := dial.DialActionPayload{
+					RequestId: d.requestId,
+				}
+				d.sendOutputMessage(dial.DialStop, payload)
+
+				// tell our agent message listener to stop processing incoming stream messages
+				d.closed = true
+				break
 			} else {
-				d.logger.Errorf("error reading from local tcp connection: %s", err)
-			}
 
-			// let the agent know we need to stop
-			payload := dial.DialActionPayload{
-				RequestId: d.requestId,
-			}
-			d.sendOutputMessage(dial.DialStop, payload)
+				// Build and send whatever we get from the local tcp connection to the agent
+				dataToSend := base64.StdEncoding.EncodeToString(buf[:n])
+				payload := dial.DialInputActionPayload{
+					RequestId:      d.requestId,
+					SequenceNumber: sequenceNumber,
+					Data:           dataToSend,
+				}
+				d.sendOutputMessage(dial.DialInput, payload)
 
-			// tell our agent message listener to stop processing incoming stream messages
-			d.doneChan <- true
-			break
-		} else {
-			// Build and send whatever we get from the local tcp connection to the agent
-			dataToSend := base64.StdEncoding.EncodeToString(buf[:n])
-			payload := dial.DialInputActionPayload{
-				RequestId:      d.requestId,
-				SequenceNumber: sequenceNumber,
-				Data:           dataToSend,
+				sequenceNumber += 1
 			}
-			d.sendOutputMessage(dial.DialInput, payload)
-
-			sequenceNumber += 1
 		}
-	}
+	}()
 
 	return nil
 }
@@ -139,15 +149,23 @@ func (d *DialAction) sendOutputMessage(action dial.DialSubAction, payload interf
 
 }
 
+func (d *DialAction) closeAction() {
+	d.logger.Infof("Closing dial action with request id: %s", d.requestId)
+	d.closed = true
+
+	// this signals to the parent plugin that we're done with the action
+	close(d.outputChan)
+
+	d.tmb.Kill(fmt.Errorf("done with the only action this datachannel will ever do"))
+}
+
 func (d *DialAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) {
 	if wrappedAction.Action == string(dial.DialStop) {
-
-		// this signals to the parent plugin that we're done with the action
-		close(d.outputChan)
+		d.closeAction()
 	}
 }
 
 func (d *DialAction) ReceiveStream(smessage smsg.StreamMessage) {
-	d.logger.Debugf("Stream action received %v stream", smessage.Type)
+	d.logger.Debugf("Dial action received %v stream, message count: %d", smessage.Type, len(d.streamInputChan)+1)
 	d.streamInputChan <- smessage
 }

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -3,7 +3,6 @@ package dial
 import (
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"time"
@@ -150,13 +149,10 @@ func (d *DialAction) sendOutputMessage(action dial.DialSubAction, payload interf
 }
 
 func (d *DialAction) closeAction() {
-	d.logger.Infof("Closing dial action with request id: %s", d.requestId)
 	d.closed = true
 
 	// this signals to the parent plugin that we're done with the action
 	close(d.outputChan)
-
-	d.tmb.Kill(fmt.Errorf("done with the only action this datachannel will ever do"))
 }
 
 func (d *DialAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) {

--- a/bctl/daemon/plugin/db/db.go
+++ b/bctl/daemon/plugin/db/db.go
@@ -73,9 +73,7 @@ func (d *DbDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
 func (d *DbDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
 	// find action by requestid in map and push stream message to it
 	if act, ok := d.getActionsMap(smessage.RequestId); ok {
-		d.logger.Infof("BLOCKED HERE?")
 		act.ReceiveStream(smessage)
-		d.logger.Infof("NO")
 		return nil
 	}
 
@@ -112,7 +110,7 @@ func (d *DbDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byte
 }
 
 func (d *DbDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
-	d.logger.Infof("WE GOT SOMETHING")
+	d.logger.Infof("Db plugin received keysplitting message with action: %s", action)
 
 	// currently the only keysplitting message we care about is the acknowledgement of our request for the agent to stop the dial action
 	if action == string(bzdial.DialStop) {
@@ -171,8 +169,11 @@ func (d *DbDaemonPlugin) Feed(food interface{}) error {
 				if more {
 					d.outputQueue <- m
 				} else {
-					d.logger.Infof("CLOSING ACTION ON DAEMON")
+					d.logger.Infof("Closing db %s action with request id: %s", dbFood.Action, requestId)
 					d.deleteActionsMap(requestId)
+
+					d.tmb.Kill(fmt.Errorf("done with the only action this datachannel will ever do"))
+
 					return
 				}
 			}

--- a/bctl/daemon/plugin/web/actions/webdial/webdial.go
+++ b/bctl/daemon/plugin/web/actions/webdial/webdial.go
@@ -37,8 +37,8 @@ func New(logger *logger.Logger,
 
 		requestId: requestId,
 
-		outputChan:      make(chan plugin.ActionWrapper, 10),
-		streamInputChan: make(chan smsg.StreamMessage, 10),
+		outputChan:      make(chan plugin.ActionWrapper, 50),
+		streamInputChan: make(chan smsg.StreamMessage, 50),
 
 		doneChan: make(chan bool),
 	}
@@ -182,6 +182,6 @@ func (w *WebDialAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) 
 }
 
 func (w *WebDialAction) ReceiveStream(smessage smsg.StreamMessage) {
-	w.logger.Debugf("Stream action received %v stream", smessage.Type)
+	w.logger.Debugf("web dial action received %v stream", smessage.Type)
 	w.streamInputChan <- smessage
 }

--- a/bctl/daemon/plugin/web/actions/webdial/webdial.go
+++ b/bctl/daemon/plugin/web/actions/webdial/webdial.go
@@ -46,7 +46,7 @@ func New(logger *logger.Logger,
 	return stream, stream.outputChan
 }
 
-func (w *WebDialAction) Start(tmb *tomb.Tomb, Writer http.ResponseWriter, Request *http.Request) error {
+func (w *WebDialAction) Start(tmb *tomb.Tomb, writer http.ResponseWriter, request *http.Request) error {
 	// Build the action payload to start the web action dial
 	payload := webdial.WebDialActionPayload{
 		RequestId: w.requestId,
@@ -59,7 +59,7 @@ func (w *WebDialAction) Start(tmb *tomb.Tomb, Writer http.ResponseWriter, Reques
 		ActionPayload: payloadBytes,
 	}
 
-	return w.handleHttpRequest(Writer, Request)
+	return w.handleHttpRequest(writer, request)
 }
 
 func (w *WebDialAction) handleHttpRequest(writer http.ResponseWriter, request *http.Request) error {
@@ -110,7 +110,7 @@ func (w *WebDialAction) handleHttpRequest(writer http.ResponseWriter, request *h
 				continue
 			}
 
-			w.logger.Infof("Sending interrupt signal to agent")
+			w.logger.Info("HTTP request cancelled. Sending interrupt signal to agent.")
 
 			returnPayload := bzwebdial.WebInterruptActionPayload{
 				RequestId: w.requestId,
@@ -142,7 +142,7 @@ func (w *WebDialAction) handleHttpRequest(writer http.ResponseWriter, request *h
 
 				var response webdial.WebOutputActionPayload
 				if err := json.Unmarshal(contentBytes, &response); err != nil {
-					rerr := fmt.Errorf("could not unmarshal Action Response Payload: %s", err)
+					rerr := fmt.Errorf("could not unmarshal web dial output action payload: %s", err)
 					w.logger.Error(rerr)
 					return err
 				}

--- a/bctl/daemon/plugin/web/actions/webwebsocket/webwebsocket.go
+++ b/bctl/daemon/plugin/web/actions/webwebsocket/webwebsocket.go
@@ -173,6 +173,6 @@ func (s *WebWebsocketAction) ReceiveKeysplitting(wrappedAction plugin.ActionWrap
 }
 
 func (s *WebWebsocketAction) ReceiveStream(smessage smsg.StreamMessage) {
-	s.logger.Debugf("Stream action received %v stream", smessage.Type)
+	s.logger.Debugf("web websocket action received %v stream", smessage.Type)
 	s.streamInputChan <- smessage
 }

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -176,14 +176,14 @@ func (w *WebDaemonPlugin) Feed(food interface{}) error {
 					w.outputQueue <- m
 				} else {
 					w.deleteActionsMap(requestId)
-					w.tmb.Kill(fmt.Errorf("killing the action only a mother plugin could ever love"))
+					w.tmb.Kill(fmt.Errorf("killing web action with request id: %s", requestId))
 					return
 				}
 			}
 		}
 	}()
 
-	w.logger.Infof("Created %s action with requestId %v", string(webFood.Action), requestId)
+	w.logger.Infof("Web plugin created a %s action with requestId %v", string(webFood.Action), requestId)
 
 	// send local tcp connection to action
 	if err := act.Start(w.tmb, webFood.Writer, webFood.Request); err != nil {

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -176,6 +176,7 @@ func (w *WebDaemonPlugin) Feed(food interface{}) error {
 					w.outputQueue <- m
 				} else {
 					w.deleteActionsMap(requestId)
+					w.tmb.Kill(fmt.Errorf("killing the action only a mother plugin could ever love"))
 					return
 				}
 			}

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -71,7 +71,7 @@ func New(parentTmb *tomb.Tomb, logger *logger.Logger, actionParams bzweb.WebActi
 }
 
 func (k *WebDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
-	k.logger.Debugf("Stream action received %v stream", smessage.Type)
+	k.logger.Debugf("Web dial action received %v stream", smessage.Type)
 	k.streamInputChan <- smessage
 }
 

--- a/bctl/daemon/servers/dbserver/dbserver.go
+++ b/bctl/daemon/servers/dbserver/dbserver.go
@@ -3,7 +3,6 @@ package dbserver
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"os"
 
@@ -28,7 +27,7 @@ type DbServer struct {
 	tmb       tomb.Tomb
 
 	// Db connections only require a single datachannel
-	datachannel *datachannel.DataChannel
+	// datachannel *datachannel.DataChannel
 
 	// Handler to select message types
 	targetSelectHandler func(msg am.AgentMessage) (string, error)
@@ -109,20 +108,21 @@ func StartDbServer(logger *logger.Logger,
 		}
 
 		logger.Infof("Accepting new tcp connection")
+
+		// create our new datachannel in its own go routine so that we can accept other tcp connections
 		go func() {
-			if datachannel, err := listener.newDataChannel(string(bzdb.Dial), listener.websocket); err == nil {
+			if dc, err := listener.newDataChannel(string(bzdb.Dial), listener.websocket); err == nil {
+
 				// Start the dial plugin
 				food := bzdb.DbFood{
 					Action: bzdb.Dial,
 					Conn:   conn,
 				}
-
-				datachannel.Feed(food)
+				dc.Feed(food)
 			} else {
 				logger.Errorf("error starting datachannel: %s", err)
 			}
 		}()
-
 	}
 }
 
@@ -138,54 +138,49 @@ func (h *DbServer) newWebsocket(wsId string) error {
 }
 
 // for creating new datachannels
-func (h *DbServer) newDataChannel(action string, websocket *websocket.Websocket) (*datachannel.DataChannel, error) {
+func (d *DbServer) newDataChannel(action string, websocket *websocket.Websocket) (*datachannel.DataChannel, error) {
 	// every datachannel gets a uuid to distinguish it so a single websockets can map to multiple datachannels
 	dcId := uuid.New().String()
-	subLogger := h.logger.GetDatachannelLogger(dcId)
+	subLogger := d.logger.GetDatachannelLogger(dcId)
 
-	h.logger.Infof("Creating new datachannel id: %v", dcId)
+	d.logger.Infof("Creating new datachannel id: %s", dcId)
 
 	// Build the actionParams to send to the datachannel to start the plugin
 	actionParams := bzdb.DbActionParams{
-		RemotePort: h.remotePort,
-		RemoteHost: h.remoteHost,
+		RemotePort: d.remotePort,
+		RemoteHost: d.remoteHost,
 	}
-
-	actionParamsMarshalled, marshalErr := json.Marshal(actionParams)
-	if marshalErr != nil {
-		h.logger.Error(fmt.Errorf("error marshalling action params for db"))
-		return nil, marshalErr
-	}
+	actionParamsMarshalled, _ := json.Marshal(actionParams)
 
 	action = "db/" + action
-	if datachannel, dcTmb, err := datachannel.New(subLogger, dcId, &h.tmb, websocket, h.refreshTokenCommand, h.configPath, action, actionParamsMarshalled, h.agentPubKey); err != nil {
-		h.logger.Error(err)
-		return datachannel, err
+	if dc, dcTmb, err := datachannel.New(subLogger, dcId, &d.tmb, websocket, d.refreshTokenCommand, d.configPath, action, actionParamsMarshalled, d.agentPubKey); err != nil {
+		d.logger.Error(err)
+		return nil, err
 	} else {
 
 		// create a function to listen to the datachannel dying and then laugh
 		go func() {
 			for {
 				select {
-				case <-h.tmb.Dying():
-					datachannel.Close(errors.New("db server closing"))
+				case <-d.tmb.Dying():
+					dc.Close(errors.New("db server closing"))
 					return
 				case <-dcTmb.Dying():
 					// Wait until everything is dead and any close processes are sent before killing the datachannel
 					dcTmb.Wait()
 
 					// notify agent to close the datachannel
-					h.logger.Info("Sending DataChannel Close")
+					d.logger.Info("Sending DataChannel Close")
 					cdMessage := am.AgentMessage{
 						ChannelId:   dcId,
 						MessageType: string(am.CloseDataChannel),
 					}
-					h.websocket.Send(cdMessage)
+					d.websocket.Send(cdMessage)
 
 					return
 				}
 			}
 		}()
-		return datachannel, nil
+		return dc, nil
 	}
 }

--- a/bctl/daemon/servers/dbserver/dbserver.go
+++ b/bctl/daemon/servers/dbserver/dbserver.go
@@ -26,9 +26,6 @@ type DbServer struct {
 	websocket *websocket.Websocket
 	tmb       tomb.Tomb
 
-	// Db connections only require a single datachannel
-	// datachannel *datachannel.DataChannel
-
 	// Handler to select message types
 	targetSelectHandler func(msg am.AgentMessage) (string, error)
 
@@ -127,12 +124,12 @@ func StartDbServer(logger *logger.Logger,
 }
 
 // for creating new websockets
-func (h *DbServer) newWebsocket(wsId string) error {
-	subLogger := h.logger.GetWebsocketLogger(wsId)
-	if wsClient, err := websocket.New(subLogger, h.serviceUrl, h.params, h.headers, h.targetSelectHandler, autoReconnect, getChallenge, h.refreshTokenCommand, websocket.Db); err != nil {
+func (d *DbServer) newWebsocket(wsId string) error {
+	subLogger := d.logger.GetWebsocketLogger(wsId)
+	if wsClient, err := websocket.New(subLogger, d.serviceUrl, d.params, d.headers, d.targetSelectHandler, autoReconnect, getChallenge, d.refreshTokenCommand, websocket.Db); err != nil {
 		return err
 	} else {
-		h.websocket = wsClient
+		d.websocket = wsClient
 		return nil
 	}
 }

--- a/bctl/daemon/servers/webserver/webserver.go
+++ b/bctl/daemon/servers/webserver/webserver.go
@@ -82,9 +82,8 @@ func StartWebServer(logger *logger.Logger,
 	// Create HTTP Server listens for incoming kubectl commands
 	go func() {
 		// Define our http handlers
-		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			listener.handleHttp(logger, w, r)
-		})
+		// library will automatically put each call in its own thread
+		http.HandleFunc("/", listener.handleHttp)
 
 		if err := http.ListenAndServe(fmt.Sprintf("%s:%s", localHost, localPort), nil); err != nil {
 			logger.Error(err)
@@ -94,32 +93,29 @@ func StartWebServer(logger *logger.Logger,
 	return nil
 }
 
-func (w *WebServer) handleHttp(logger *logger.Logger, writer http.ResponseWriter, reader *http.Request) {
-	// Determine if we are trying to upgrade the request
-	isWebsocketRequest := reader.Header.Get("Upgrade")
-
+func (w *WebServer) handleHttp(writer http.ResponseWriter, request *http.Request) {
 	action := bzweb.Dial
+
 	// This will work for http 1.1 and that is what we need to support
 	// Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Upgrade
 	// Ref: https://datatracker.ietf.org/doc/html/rfc6455#section-1.7
+	isWebsocketRequest := request.Header.Get("Upgrade")
 	if isWebsocketRequest == "websocket" {
 		action = bzweb.Websocket
 	}
 
 	food := bzweb.WebFood{
 		Action:  action,
-		Request: reader,
+		Request: request,
 		Writer:  writer,
 	}
 
 	// create our new datachannel in its own go routine so that we can accept other http connections
-	go func() {
-		if dc, err := w.newDataChannel(string(action), w.websocket); err == nil {
-			dc.Feed(food)
-		} else {
-			logger.Errorf("error starting datachannel: %s", err)
-		}
-	}()
+	if dc, err := w.newDataChannel(string(action), w.websocket); err == nil {
+		dc.Feed(food)
+	} else {
+		w.logger.Errorf("error starting datachannel: %s", err)
+	}
 }
 
 // for creating new websockets
@@ -134,28 +130,28 @@ func (h *WebServer) newWebsocket(wsId string) error {
 }
 
 // for creating new datachannels
-func (h *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websocket) (*datachannel.DataChannel, error) {
+func (w *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websocket) (*datachannel.DataChannel, error) {
 	// every datachannel gets a uuid to distinguish it so a single websockets can map to multiple datachannels
 	dcId := uuid.New().String()
-	subLogger := h.logger.GetDatachannelLogger(dcId)
+	subLogger := w.logger.GetDatachannelLogger(dcId)
 
-	h.logger.Infof("Creating new datachannel id: %v", dcId)
+	w.logger.Infof("Creating new datachannel id: %v", dcId)
 
 	// Build the actionParams to send to the datachannel to start the plugin
 	actionParams := bzweb.WebActionParams{
-		RemotePort: h.targetPort,
-		RemoteHost: h.targetHost,
+		RemotePort: w.targetPort,
+		RemoteHost: w.targetHost,
 	}
 
 	actionParamsMarshalled, marshalErr := json.Marshal(actionParams)
 	if marshalErr != nil {
-		h.logger.Error(fmt.Errorf("error marshalling action params for web"))
+		w.logger.Error(fmt.Errorf("error marshalling action params for web"))
 		return nil, marshalErr
 	}
 
 	action = "web/" + action
-	if datachannel, dcTmb, err := datachannel.New(subLogger, dcId, &h.tmb, websocket, h.refreshTokenCommand, h.configPath, action, actionParamsMarshalled, h.agentPubKey); err != nil {
-		h.logger.Error(err)
+	if datachannel, dcTmb, err := datachannel.New(subLogger, dcId, &w.tmb, websocket, w.refreshTokenCommand, w.configPath, action, actionParamsMarshalled, w.agentPubKey); err != nil {
+		w.logger.Error(err)
 		return datachannel, err
 	} else {
 
@@ -163,7 +159,7 @@ func (h *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websock
 		go func() {
 			for {
 				select {
-				case <-h.tmb.Dying():
+				case <-w.tmb.Dying():
 					datachannel.Close(errors.New("web server closing"))
 					return
 				case <-dcTmb.Dying():
@@ -171,15 +167,13 @@ func (h *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websock
 					dcTmb.Wait()
 
 					// notify agent to close the datachannel
-					h.logger.Info("Sending DataChannel Close")
+					w.logger.Info("Sending DataChannel Close")
 					cdMessage := am.AgentMessage{
 						ChannelId:   dcId,
 						MessageType: string(am.CloseDataChannel),
 					}
-					h.websocket.Send(cdMessage)
+					w.websocket.Send(cdMessage)
 
-					// close our websocket
-					h.websocket.Close(errors.New("all datachannels closed, closing websocket"))
 					return
 				}
 			}


### PR DESCRIPTION
## Description of the change

There were a few issues that this PR solves:

1. Now that we're creating a lot of new datachannels, we have to also kill them. Because we weren't, our garbage collection wasn't working correctly and we had all these closed listeners listening on a port which was confusing everyone and making it hard to create new listeners.
          + this revealed a bug where we were actually never closing datachannels on the agent.
3. DID YOU KNOW `lconn.Write()` BLOCKS FOREVER IF YOU WRITE TOO FAST TO IT?
4. We needed to be listening and ignoring messages in the db dial action.  Because we weren't, the streamqueue was filling up and creating a blocking call for the db.
5. We needed to send the final bytes of the read where we get our io.EOF error because we were losing the final message
6. There's more but the 5 above were the most significant.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1592

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: