### PR TITLE
Fix/web

### DIFF
--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -151,6 +151,7 @@ func (d *DataChannel) sendError(errType rrr.ErrorType, err error) {
 }
 
 func (d *DataChannel) Receive(agentMessage am.AgentMessage) {
+	// only push to input channel if we're alive (aka not in the process of dying or already dead)
 	if d.tmb.Err() == tomb.ErrStillAlive {
 		d.inputChan <- agentMessage
 	}

--- a/bctl/agent/plugin/db/actions/dial/dial.go
+++ b/bctl/agent/plugin/db/actions/dial/dial.go
@@ -144,7 +144,7 @@ func (d *Dial) start(dialActionRequest dial.DialActionPayload, action string) (s
 			d.closed = true
 		}()
 
-		sequenceNumber := 1
+		sequenceNumber := 0
 		buff := make([]byte, chunkSize)
 
 		for {

--- a/bctl/agent/plugin/web/actions/webdial/webdial.go
+++ b/bctl/agent/plugin/web/actions/webdial/webdial.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"time"
 
 	"bastionzero.com/bctl/v1/bzerolib/bzhttp"
 	"bastionzero.com/bctl/v1/bzerolib/logger"
@@ -84,7 +83,7 @@ func (w *WebDial) Receive(action string, actionPayload []byte) (string, []byte, 
 
 		// give our streamoutputchan time to process all the messages we sent while the interrupt was getting here
 		// CWC-1588: We need to revisit the assumption of one plugin to many actions in order to solve this better
-		time.Sleep(2 * time.Second)
+		//time.Sleep(2 * time.Second)
 
 		// this return payload tells the daemon to close the action on their side
 		returnPayload := bzwebdial.WebInterruptActionPayload{
@@ -185,7 +184,7 @@ func (w *WebDial) HandleNewHttpRequest(action string, dataIn WebInputActionPaylo
 							StatusCode: http.StatusBadGateway,
 							RequestId:  dataIn.RequestId,
 							Headers:    map[string][]string{},
-							Content:    []byte{},
+							Content:    buf[:numBytes],
 						}
 
 						w.sendWebDataStreamMessage(&responsePayload, sequenceNumber, smsg.WebError)

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -306,7 +306,6 @@ func (d *DataChannel) send(messageType am.MessageType, messagePayload interface{
 	}
 
 	// Push message to websocket channel output
-	d.logger.Infof("SENDING %s", messageType)
 	d.websocket.Send(agentMessage)
 	return nil
 }

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"net"
-	"time"
 
 	"gopkg.in/tomb.v2"
 
@@ -57,6 +56,11 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 	// Listen to stream messages coming from the agent, and forward to our local connection
 	go func() {
 		defer lconn.Close()
+
+		// variables for ensuring we receive stream messages in order
+		expectedSequenceNumber := 0
+		streamMessages := make(map[int]smsg.StreamMessage)
+
 		for {
 			select {
 			case <-tmb.Dying():
@@ -65,26 +69,37 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 				if d.closed {
 					return
 				}
+				streamMessages[data.SequenceNumber] = data
 
-				switch smsg.StreamType(data.Type) {
-				case smsg.DbStream:
-					if contentBytes, err := base64.StdEncoding.DecodeString(data.Content); err != nil {
-						d.logger.Errorf("could not decode db stream content: %s", err)
-					} else {
-						go func() {
-							time.Sleep(time.Millisecond)
+				// process the incoming stream messages *in order*
+				streamMessage, ok := streamMessages[expectedSequenceNumber]
+				for ok {
+					switch smsg.StreamType(streamMessage.Type) {
+					case smsg.DbStream:
+						if contentBytes, err := base64.StdEncoding.DecodeString(streamMessage.Content); err != nil {
+							d.logger.Errorf("could not decode db stream content: %s", err)
+						} else {
 							lconn.Write(contentBytes) // did you know this blocks forever if you write too fast to it? yeah.
-						}()
+						}
+					case smsg.DbStreamEnd:
+
+						// The agent has closed the connection, close the local connection as well
+						d.logger.Info("remote tcp connection has been closed, closing local tcp connection")
+						d.closed = true
+
+						return
+					default:
+						d.logger.Errorf("unhandled stream type: %s", streamMessage.Type)
 					}
-				case smsg.DbStreamEnd:
 
-					// The agent has closed the connection, close the local connection as well
-					d.logger.Info("remote tcp connection has been closed, closing local tcp connection")
-					d.closed = true
+					// remove the message we've already processed
+					delete(streamMessages, expectedSequenceNumber)
 
-					return
-				default:
-					d.logger.Errorf("unhandled stream type: %s", data.Type)
+					// increment our sequence number
+					expectedSequenceNumber += 1
+
+					// grab our next message, if there is one
+					streamMessage, ok = streamMessages[expectedSequenceNumber]
 				}
 			}
 		}

--- a/bctl/daemon/plugin/db/actions/dial/dial.go
+++ b/bctl/daemon/plugin/db/actions/dial/dial.go
@@ -72,8 +72,7 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 				streamMessages[data.SequenceNumber] = data
 
 				// process the incoming stream messages *in order*
-				streamMessage, ok := streamMessages[expectedSequenceNumber]
-				for ok {
+				for streamMessage, ok := streamMessages[expectedSequenceNumber]; ok; streamMessage, ok = streamMessages[expectedSequenceNumber] {
 					switch smsg.StreamType(streamMessage.Type) {
 					case smsg.DbStream:
 						if contentBytes, err := base64.StdEncoding.DecodeString(streamMessage.Content); err != nil {
@@ -97,9 +96,6 @@ func (d *DialAction) Start(tmb *tomb.Tomb, lconn *net.TCPConn) error {
 
 					// increment our sequence number
 					expectedSequenceNumber += 1
-
-					// grab our next message, if there is one
-					streamMessage, ok = streamMessages[expectedSequenceNumber]
 				}
 			}
 		}

--- a/bctl/daemon/plugin/web/actions/webdial/webdial.go
+++ b/bctl/daemon/plugin/web/actions/webdial/webdial.go
@@ -142,8 +142,7 @@ func (w *WebDialAction) handleHttpRequest(writer http.ResponseWriter, request *h
 				w.streamMessages[data.SequenceNumber] = data
 
 				// process the incoming stream messages *in order*
-				nextMessage, ok := w.streamMessages[w.expectedSequenceNumber]
-				for ok {
+				for nextMessage, ok := w.streamMessages[w.expectedSequenceNumber]; ok; nextMessage, ok = w.streamMessages[w.expectedSequenceNumber] {
 					var response webdial.WebOutputActionPayload
 					if contentBytes, err := base64.StdEncoding.DecodeString(nextMessage.Content); err != nil {
 						return err
@@ -182,8 +181,6 @@ func (w *WebDialAction) handleHttpRequest(writer http.ResponseWriter, request *h
 
 						// increment our sequence number
 						w.expectedSequenceNumber += 1
-
-						nextMessage, ok = w.streamMessages[w.expectedSequenceNumber]
 					}
 				}
 			default:

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -75,16 +75,17 @@ func (k *WebDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
 	k.streamInputChan <- smessage
 }
 
-func (k *WebDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
+func (w *WebDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
 	// find action by requestid in map and push stream message to it
-	if act, ok := k.getActionsMap(smessage.RequestId); ok {
+	if act, ok := w.getActionsMap(smessage.RequestId); ok {
 		act.ReceiveStream(smessage)
-		return nil
 	}
 
-	rerr := fmt.Errorf("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
-	k.logger.Error(rerr)
-	return rerr
+	w.logger.Tracef("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
+	return nil
+	// rerr := fmt.Errorf("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
+	// k.logger.Error(rerr)
+	// return rerr
 }
 
 func (k *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byte) (string, []byte, error) {

--- a/bctl/daemon/plugin/web/web.go
+++ b/bctl/daemon/plugin/web/web.go
@@ -14,7 +14,6 @@ import (
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	"bastionzero.com/bctl/v1/bzerolib/plugin"
 	bzweb "bastionzero.com/bctl/v1/bzerolib/plugin/web"
-	bzwebdial "bastionzero.com/bctl/v1/bzerolib/plugin/web/actions/webdial"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 )
 
@@ -70,9 +69,9 @@ func New(parentTmb *tomb.Tomb, logger *logger.Logger, actionParams bzweb.WebActi
 	return &plugin, nil
 }
 
-func (k *WebDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
-	k.logger.Debugf("Web dial action received %v stream", smessage.Type)
-	k.streamInputChan <- smessage
+func (w *WebDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
+	w.logger.Debugf("Web dial action received %v stream", smessage.Type)
+	w.streamInputChan <- smessage
 }
 
 func (w *WebDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
@@ -83,30 +82,27 @@ func (w *WebDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
 
 	w.logger.Tracef("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
 	return nil
-	// rerr := fmt.Errorf("unknown request ID: %v. This is expected if the action has already been completed", smessage.RequestId)
-	// k.logger.Error(rerr)
-	// return rerr
 }
 
-func (k *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byte) (string, []byte, error) {
+func (w *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byte) (string, []byte, error) {
 	// First, process the incoming message
-	if err := k.processKeysplitting(action, actionPayload); err != nil {
+	if err := w.processKeysplitting(action, actionPayload); err != nil {
 		return "", []byte{}, err
 	}
 
 	// Now that we've received, we wait for any new outgoing commands.  Because the existence of any
 	// such command is dependent on the user, there may not be one waiting so we wait for it.
-	k.logger.Info("Waiting for input...")
+	w.logger.Info("Waiting for input...")
 
 	select {
-	case <-k.tmb.Dying():
+	case <-w.tmb.Dying():
 		return "", []byte{}, nil
-	case actionMessage := <-k.outputQueue: // some action's got something to say
-		k.logger.Infof("Sending input from action: %v", actionMessage.Action)
+	case actionMessage := <-w.outputQueue: // some action's got something to say
+		w.logger.Infof("Sending input from action: %v", actionMessage.Action)
 
 		// turn the actionPayload into bytes and return it
 		if actionPayloadBytes, err := json.Marshal(actionMessage.ActionPayload); err != nil {
-			k.logger.Infof("actionPayload: %+v", actionPayload)
+			w.logger.Infof("actionPayload: %+v", actionPayload)
 			return "", []byte{}, fmt.Errorf("could not marshal actionPayload json: %s", err)
 		} else {
 			return actionMessage.Action, actionPayloadBytes, nil
@@ -115,24 +111,9 @@ func (k *WebDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byt
 }
 
 func (w *WebDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
-
-	// we only care about a single action right now
-	if action == string(bzwebdial.WebDialInterrupt) {
-		var webInterrupt bzwebdial.WebInterruptActionPayload
-		if err := json.Unmarshal(actionPayload, &webInterrupt); err != nil {
-			return fmt.Errorf("could not unmarshal json: %s", err)
-		} else {
-
-			// push the keysplitting message to the action
-			if act, ok := w.getActionsMap(webInterrupt.RequestId); ok {
-				act.ReceiveKeysplitting(plugin.ActionWrapper{
-					Action:        action,
-					ActionPayload: actionPayload,
-				})
-				return nil
-			}
-		}
-	}
+	// the only keysplitting message that we would receive is the ack for our web action interrupt
+	// we don't do anything with it on the daemon side, so we receive it here and it will get logged
+	// but no particular action will be taken
 	return nil
 }
 
@@ -194,25 +175,25 @@ func (w *WebDaemonPlugin) Feed(food interface{}) error {
 	return nil
 }
 
-func (k *WebDaemonPlugin) updateActionsMap(newAction IWebDaemonAction, id string) {
+func (w *WebDaemonPlugin) updateActionsMap(newAction IWebDaemonAction, id string) {
 	// Helper function so we avoid writing to this map at the same time
-	k.actionMapLock.Lock()
-	defer k.actionMapLock.Unlock()
+	w.actionMapLock.Lock()
+	defer w.actionMapLock.Unlock()
 
-	k.actions[id] = newAction
+	w.actions[id] = newAction
 }
 
-func (k *WebDaemonPlugin) deleteActionsMap(rid string) {
-	k.actionMapLock.Lock()
-	defer k.actionMapLock.Unlock()
+func (w *WebDaemonPlugin) deleteActionsMap(rid string) {
+	w.actionMapLock.Lock()
+	defer w.actionMapLock.Unlock()
 
-	delete(k.actions, rid)
+	delete(w.actions, rid)
 }
 
-func (k *WebDaemonPlugin) getActionsMap(rid string) (IWebDaemonAction, bool) {
-	k.actionMapLock.Lock()
-	defer k.actionMapLock.Unlock()
+func (w *WebDaemonPlugin) getActionsMap(rid string) (IWebDaemonAction, bool) {
+	w.actionMapLock.Lock()
+	defer w.actionMapLock.Unlock()
 
-	act, ok := k.actions[rid]
+	act, ok := w.actions[rid]
 	return act, ok
 }

--- a/bctl/daemon/servers/webserver/webserver.go
+++ b/bctl/daemon/servers/webserver/webserver.go
@@ -135,13 +135,15 @@ func (w *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websock
 	dcId := uuid.New().String()
 	subLogger := w.logger.GetDatachannelLogger(dcId)
 
-	w.logger.Infof("Creating new datachannel id: %v", dcId)
+	w.logger.Infof("Creating new datachannel for web with id: %v", dcId)
 
 	// Build the actionParams to send to the datachannel to start the plugin
 	actionParams := bzweb.WebActionParams{
 		RemotePort: w.targetPort,
 		RemoteHost: w.targetHost,
 	}
+
+	w.logger.Infof("REMOTE HOST: %s, REMOTE PORT: %s", w.targetHost, w.targetPort)
 
 	actionParamsMarshalled, marshalErr := json.Marshal(actionParams)
 	if marshalErr != nil {

--- a/bctl/daemon/servers/webserver/webserver.go
+++ b/bctl/daemon/servers/webserver/webserver.go
@@ -143,8 +143,6 @@ func (w *WebServer) newDataChannel(action string, websocket *bzwebsocket.Websock
 		RemoteHost: w.targetHost,
 	}
 
-	w.logger.Infof("REMOTE HOST: %s, REMOTE PORT: %s", w.targetHost, w.targetPort)
-
 	actionParamsMarshalled, marshalErr := json.Marshal(actionParams)
 	if marshalErr != nil {
 		w.logger.Error(fmt.Errorf("error marshalling action params for web"))

--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -340,7 +340,7 @@ func (w *Websocket) Connect() error {
 
 		// If we have a private key, we must solve the challenge
 		if solvedChallenge, err := agentController.GetChallenge(w.params["target_id"], config.Data.TargetName, config.Data.PrivateKey, w.params["version"]); err != nil {
-			return fmt.Errorf("error getting challenge: %s", err)
+			return fmt.Errorf("error getting challenge for agent with public key %s: %s", config.Data.PublicKey, err)
 		} else {
 			w.params["solved_challenge"] = solvedChallenge
 		}

--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -250,7 +250,6 @@ func (w *Websocket) receive() error {
 
 					if channel, ok := w.getChannel(agentMessage.ChannelId); ok {
 						go func() {
-							w.logger.Infof("WEBSOCKET RECEIVING %s", agentMessage.MessageType)
 							channel.Receive(agentMessage)
 						}()
 					} else {
@@ -325,7 +324,6 @@ func (w *Websocket) processOutput(agentMessage am.AgentMessage) {
 
 // Function to write signalr message to websocket
 func (w *Websocket) Send(agentMessage am.AgentMessage) {
-	w.logger.Infof("WEBSOCKET SENDING %s", agentMessage.MessageType)
 	w.sendQueue <- agentMessage
 }
 

--- a/bzerolib/channels/websocket/websocket.go
+++ b/bzerolib/channels/websocket/websocket.go
@@ -185,13 +185,14 @@ func New(logger *logger.Logger,
 }
 
 func (w *Websocket) Close(reason error) {
+	w.logger.Infof("websocket closing because: %s", reason)
+
 	// close all of our existing datachannels
 	for _, channel := range w.channels {
 		channel.Close(reason)
 	}
 
 	// tell our tmb to clean up after us
-	w.logger.Infof("websocket closed because: %s", reason)
 	w.tmb.Kill(reason)
 	w.tmb.Wait()
 }
@@ -249,6 +250,7 @@ func (w *Websocket) receive() error {
 
 					if channel, ok := w.getChannel(agentMessage.ChannelId); ok {
 						go func() {
+							w.logger.Infof("WEBSOCKET RECEIVING %s", agentMessage.MessageType)
 							channel.Receive(agentMessage)
 						}()
 					} else {
@@ -323,6 +325,7 @@ func (w *Websocket) processOutput(agentMessage am.AgentMessage) {
 
 // Function to write signalr message to websocket
 func (w *Websocket) Send(agentMessage am.AgentMessage) {
+	w.logger.Infof("WEBSOCKET SENDING %s", agentMessage.MessageType)
 	w.sendQueue <- agentMessage
 }
 

--- a/bzerolib/controllers/agentcontroller/agentcontroller.go
+++ b/bzerolib/controllers/agentcontroller/agentcontroller.go
@@ -61,7 +61,7 @@ func (c *AgentController) GetChallenge(targetId string, targetName string, priva
 	// Make our POST request
 	response, err := bzhttp.PostContent(c.logger, challengeEndpointFormatted, "application/json", challengeJson)
 	if err != nil {
-		return "", fmt.Errorf("error making post request to challenge agent. Error: %s. Response: %+v", err, response)
+		return "", fmt.Errorf("error making post request to challenge agent. Request: %+v Error: %s. Response: %+v", challengeRequest, err, response)
 	}
 	defer response.Body.Close()
 


### PR DESCRIPTION
## Description of the change

The web plugin stopped working with our grafana instance. This PR fixes the main reasons for that:

1. Datachannels were raising a panic when they were dying after the web request was finished. This was happening because we were registering new defer functions in a for loop so if we received 4 stream messages from the agent, the daemon would call this function 4 times which resulted in it trying to close a channel 4 times which was throwing a panic.
2. The daemon was receiving stream messages out of order.

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1602

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: