### PR TITLE
Adds shell plugin support to the daemon

### DIFF
--- a/bctl/agent/agent.go
+++ b/bctl/agent/agent.go
@@ -122,7 +122,8 @@ func setupLogger() (*logger.Logger, error) {
 	}
 
 	// setup our loggers
-	if logger, err := logger.New(logger.DefaultLoggerConfig(logLevel), logFile); err != nil {
+	writeToConsole := true
+	if logger, err := logger.New(logger.DefaultLoggerConfig(logLevel), logFile, writeToConsole); err != nil {
 		return logger, err
 	} else {
 		logger.AddAgentVersion(getAgentVersion())

--- a/bctl/daemon/datachannel/datachannel.go
+++ b/bctl/daemon/datachannel/datachannel.go
@@ -14,6 +14,7 @@ import (
 	"bastionzero.com/bctl/v1/bctl/daemon/plugin"
 	"bastionzero.com/bctl/v1/bctl/daemon/plugin/db"
 	"bastionzero.com/bctl/v1/bctl/daemon/plugin/kube"
+	shellplugin "bastionzero.com/bctl/v1/bctl/daemon/plugin/shell"
 	"bastionzero.com/bctl/v1/bctl/daemon/plugin/web"
 	am "bastionzero.com/bctl/v1/bzerolib/channels/agentmessage"
 	"bastionzero.com/bctl/v1/bzerolib/channels/websocket"
@@ -23,6 +24,7 @@ import (
 	bzplugin "bastionzero.com/bctl/v1/bzerolib/plugin"
 	bzdb "bastionzero.com/bctl/v1/bzerolib/plugin/db"
 	bzkube "bastionzero.com/bctl/v1/bzerolib/plugin/kube"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
 	bzweb "bastionzero.com/bctl/v1/bzerolib/plugin/web"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
 )
@@ -36,9 +38,10 @@ const (
 type PluginName string
 
 const (
-	Kube PluginName = "kube"
-	Db   PluginName = "db"
-	Web  PluginName = "web"
+	Kube  PluginName = "kube"
+	Db    PluginName = "db"
+	Web   PluginName = "web"
+	Shell PluginName = "shell"
 )
 
 type OpenDataChannelPayload struct {
@@ -259,7 +262,20 @@ func (d *DataChannel) startPlugin(action string, actionParams []byte) error {
 
 		// start web plugin
 		if plugin, err := web.New(&d.tmb, subLogger, webParams); err != nil {
-			return fmt.Errorf("could not start db daemon plugin: %s", err)
+			return fmt.Errorf("could not start web daemon plugin: %s", err)
+		} else {
+			d.plugin = plugin
+		}
+	case Shell:
+		// Deserialize the action params
+		var shellParams bzshell.ShellActionParams
+		if err := json.Unmarshal(actionParams, &shellParams); err != nil {
+			return fmt.Errorf("error deserializing actions params")
+		}
+
+		// start shell plugin
+		if plugin, err := shellplugin.New(&d.tmb, subLogger, shellParams); err != nil {
+			return fmt.Errorf("could not start shell daemon plugin: %s", err)
 		} else {
 			d.plugin = plugin
 		}

--- a/bctl/daemon/plugin/shell/actions/unixshell/unixshell.go
+++ b/bctl/daemon/plugin/shell/actions/unixshell/unixshell.go
@@ -1,0 +1,211 @@
+package unixshell
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"golang.org/x/sys/unix"
+	"golang.org/x/term"
+	"gopkg.in/tomb.v2"
+
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	"bastionzero.com/bctl/v1/bzerolib/plugin"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
+)
+
+const (
+	InputBufferSize   = 8 * 1024
+	InputDebounceTime = 5 * time.Millisecond
+)
+
+type UnixShell struct {
+	logger *logger.Logger
+	tmb    *tomb.Tomb
+
+	// input and output channels relative to this plugin
+	outputChan      chan plugin.ActionWrapper
+	streamInputChan chan smsg.StreamMessage
+
+	// channel where we push each individual keypress byte from StdIn
+	stdInChan chan byte
+}
+
+func New(logger *logger.Logger) (*UnixShell, chan plugin.ActionWrapper) {
+
+	shellAction := &UnixShell{
+		logger: logger,
+
+		outputChan:      make(chan plugin.ActionWrapper, 10),
+		streamInputChan: make(chan smsg.StreamMessage, 30),
+		stdInChan:       make(chan byte, InputBufferSize),
+	}
+
+	return shellAction, shellAction.outputChan
+}
+
+func (s *UnixShell) Start(tmb *tomb.Tomb) error {
+	s.tmb = tmb
+
+	// Send openShell data message to start the pty on the target
+	openShellDataMessage := bzshell.ShellOpenMessage{
+		// note the TargetUser in this data message is ignored by the agent
+		// because it is policy-checked by bzero when its sent in the SYN
+		// message when opening the data channel and should never be changed
+		// afterwards
+		TargetUser: "",
+	}
+	s.sendOutputMessage(bzshell.ShellOpen, openShellDataMessage)
+
+	// Set initial terminal dimensions and then listen for any changes to
+	// terminal size
+	s.sendTerminalSize()
+	s.listenForTerminalSizeChanges()
+
+	// listen to stream messages on input chan and write to stdout
+	go s.handleStreamMessages()
+
+	// reading Stdin in raw mode and forward keypresses after debouncing
+	go s.readStdIn()
+	go s.processStdIn()
+
+	return nil
+}
+
+func (s *UnixShell) sendOutputMessage(action bzshell.ShellSubAction, payload interface{}) {
+	// Send payload to plugin output queue
+	payloadBytes, _ := json.Marshal(payload)
+	s.outputChan <- plugin.ActionWrapper{
+		Action:        string(action),
+		ActionPayload: payloadBytes,
+	}
+}
+
+func (s *UnixShell) ReceiveKeysplitting(wrappedAction plugin.ActionWrapper) {
+	s.logger.Debugf("Shell plugin action received keysplitting message with action: %s", wrappedAction.Action)
+}
+
+func (s *UnixShell) ReceiveStream(smessage smsg.StreamMessage) {
+	s.logger.Debugf("Shell plugin action received %v stream, message count: %d", smessage.Type, len(s.streamInputChan)+1)
+	s.streamInputChan <- smessage
+}
+
+func (s *UnixShell) handleStreamMessages() {
+	for {
+		select {
+		case <-s.tmb.Dying():
+			return
+		case streamMessage := <-s.streamInputChan:
+			// process the incoming stream messages
+			switch smsg.StreamType(streamMessage.Type) {
+			case smsg.ShellStdOut:
+				if contentBytes, err := base64.StdEncoding.DecodeString(streamMessage.Content); err != nil {
+					s.logger.Errorf("Error decoding ShellStdOut stream content: %s", err)
+				} else {
+					if _, err = os.Stdout.Write(contentBytes); err != nil {
+						s.logger.Errorf("Error writing to Stdout: %s", err)
+					}
+				}
+			case smsg.ShellQuit:
+				s.tmb.Kill(fmt.Errorf("Received shell quit stream message."))
+				return
+			default:
+				s.logger.Errorf("unhandled stream type: %s", streamMessage.Type)
+			}
+		}
+	}
+}
+
+// Reads from StdIn and pushes to an input channel
+func (s *UnixShell) readStdIn() {
+	// switch stdin into 'raw' mode
+	// https://pkg.go.dev/golang.org/x/term#pkg-overview
+	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		s.logger.Errorf("Error switching std to raw mode: %s", err)
+		return
+	}
+	defer term.Restore(int(os.Stdin.Fd()), oldState)
+
+	b := make([]byte, 1)
+
+	for {
+		select {
+		case <-s.tmb.Dying():
+			return
+		default:
+			n, err := os.Stdin.Read(b)
+			if err != nil || n != 1 {
+				s.logger.Errorf("Error reading last keypress from Stdin: %s", err)
+				return
+			}
+
+			s.stdInChan <- b[0]
+		}
+	}
+}
+
+// processes input channel by debouncing all keypresses within a time interval
+func (s *UnixShell) processStdIn() {
+	defer close(s.outputChan)
+	inputBuf := make([]byte, InputBufferSize)
+
+	for {
+		select {
+		case <-s.tmb.Dying():
+			return
+		case b := <-s.stdInChan:
+			inputBuf = append(inputBuf, b)
+		case <-time.After(InputDebounceTime):
+			if len(inputBuf) >= 1 {
+				// Send all accumulated keypresses in a shellInput data message
+				dataToSend := base64.StdEncoding.EncodeToString(inputBuf)
+				shellInputDataMessage := bzshell.ShellInputMessage{
+					Data: dataToSend,
+				}
+				s.sendOutputMessage(bzshell.ShellInput, shellInputDataMessage)
+
+				// clear the input buffer by slicing it to size 0 which will still
+				// keep memory allocated for the underlying capacity of the slice
+				inputBuf = inputBuf[:0]
+			}
+		}
+	}
+}
+
+func (s *UnixShell) sendTerminalSize() {
+	if w, h, err := term.GetSize(int(os.Stdout.Fd())); err != nil {
+		s.logger.Errorf("Failed to get current terminal size %s", err)
+	} else {
+		shellResizeMessage := bzshell.ShellResizeMessage{
+			Rows: uint32(h),
+			Cols: uint32(w),
+		}
+		s.sendOutputMessage(bzshell.ShellResize, shellResizeMessage)
+	}
+}
+
+// Captures any terminal resize events using the SIGWINCH signal and send the
+// new terminal size
+func (s *UnixShell) listenForTerminalSizeChanges() {
+	ch := make(chan os.Signal, 1)
+	sig := unix.SIGWINCH
+
+	signal.Notify(ch, sig)
+	go func() {
+		for {
+			select {
+			case <-s.tmb.Dying():
+				signal.Reset(sig)
+				close(ch)
+				return
+			case <-ch:
+				s.sendTerminalSize()
+			}
+		}
+	}()
+}

--- a/bctl/daemon/plugin/shell/shellplugin.go
+++ b/bctl/daemon/plugin/shell/shellplugin.go
@@ -1,0 +1,135 @@
+package shellplugin
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"bastionzero.com/bctl/v1/bctl/daemon/plugin/shell/actions/unixshell"
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	"bastionzero.com/bctl/v1/bzerolib/plugin"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
+	"gopkg.in/tomb.v2"
+)
+
+type IShellAction interface {
+	ReceiveKeysplitting(wrappedAction plugin.ActionWrapper)
+	ReceiveStream(stream smsg.StreamMessage)
+	Start(tmb *tomb.Tomb) error
+}
+
+type ShellDaemonPlugin struct {
+	tmb    *tomb.Tomb
+	logger *logger.Logger
+
+	// Input and output channels
+	streamInputChan chan smsg.StreamMessage
+	outputQueue     chan plugin.ActionWrapper
+
+	action IShellAction
+}
+
+func New(parentTmb *tomb.Tomb, logger *logger.Logger, actionParams bzshell.ShellActionParams) (*ShellDaemonPlugin, error) {
+	shellDaemonPlugin := ShellDaemonPlugin{
+		tmb:             parentTmb,
+		logger:          logger,
+		streamInputChan: make(chan smsg.StreamMessage, 25),
+		outputQueue:     make(chan plugin.ActionWrapper, 25),
+	}
+
+	// listener for processing any incoming stream messages, since they are not treated as part of
+	// the keysplitting synchronous chain
+	go func() {
+		for {
+			select {
+			case <-shellDaemonPlugin.tmb.Dying():
+				return
+			case streamMessage := <-shellDaemonPlugin.streamInputChan:
+				if err := shellDaemonPlugin.processStream(streamMessage); err != nil {
+					shellDaemonPlugin.logger.Error(err)
+				}
+			}
+		}
+	}()
+
+	// Create the UnixShell action
+	actLogger := logger.GetActionLogger(string(bzshell.UnixShell))
+	var actOutputChan chan plugin.ActionWrapper
+	shellDaemonPlugin.action, actOutputChan = unixshell.New(actLogger)
+
+	// listen to shell action output channel and push to outputqueue. If output
+	// channel is done then close the shell daemon plugin
+	go func() {
+		for {
+			select {
+			case <-shellDaemonPlugin.tmb.Dying():
+				return
+			case m, more := <-actOutputChan:
+				if more {
+					shellDaemonPlugin.outputQueue <- m
+				} else {
+					shellDaemonPlugin.logger.Infof("Closing shell plugin")
+					shellDaemonPlugin.tmb.Kill(fmt.Errorf("done with the only action this datachannel will ever do"))
+					return
+				}
+			}
+		}
+	}()
+
+	// Start the shell action
+	if err := shellDaemonPlugin.action.Start(shellDaemonPlugin.tmb); err != nil {
+		return &shellDaemonPlugin, fmt.Errorf("Error starting the shell action: %s", err)
+	}
+
+	return &shellDaemonPlugin, nil
+}
+
+func (s *ShellDaemonPlugin) ReceiveStream(smessage smsg.StreamMessage) {
+	s.logger.Debugf("shell plugin received %v stream", smessage.Type)
+	s.streamInputChan <- smessage
+}
+
+func (d *ShellDaemonPlugin) processStream(smessage smsg.StreamMessage) error {
+	if d.action != nil {
+		d.action.ReceiveStream(smessage)
+		return nil
+	} else {
+		return fmt.Errorf("shell plugin received stream message before an action was created. Ignoring")
+	}
+}
+
+func (s *ShellDaemonPlugin) ReceiveKeysplitting(action string, actionPayload []byte) (string, []byte, error) {
+	s.logger.Infof("Received a keysplitting message with action: %s", action)
+	// First, process the incoming message
+	if err := s.processKeysplitting(action, actionPayload); err != nil {
+		return "", []byte{}, err
+	}
+
+	// Now that we've received, we wait for any new outgoing commands.  Because the existence of any
+	// such command is dependent on the user, there may not be one waiting so we wait for it.
+	s.logger.Info("Waiting for input...")
+
+	select {
+	case <-s.tmb.Dying():
+		return "", []byte{}, nil
+	case actionMessage := <-s.outputQueue: // some action's got something to say
+		s.logger.Infof("Sending input from action: %v", actionMessage.Action)
+
+		// turn the actionPayload into bytes and return it
+		if actionPayloadBytes, err := json.Marshal(actionMessage.ActionPayload); err != nil {
+			s.logger.Infof("actionPayload: %+v", actionPayload)
+			return "", []byte{}, fmt.Errorf("could not marshal actionPayload json: %s", err)
+		} else {
+			return actionMessage.Action, actionPayloadBytes, nil
+		}
+	}
+}
+
+func (s *ShellDaemonPlugin) processKeysplitting(action string, actionPayload []byte) error {
+	s.logger.Infof("Shell plugin received keysplitting message with action: %s", action)
+	return nil
+}
+
+func (s *ShellDaemonPlugin) Feed(food interface{}) error {
+	return nil
+}

--- a/bctl/daemon/servers/shellserver/shellserver.go
+++ b/bctl/daemon/servers/shellserver/shellserver.go
@@ -1,0 +1,141 @@
+package shellserver
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"bastionzero.com/bctl/v1/bctl/daemon/datachannel"
+	am "bastionzero.com/bctl/v1/bzerolib/channels/agentmessage"
+	"bastionzero.com/bctl/v1/bzerolib/channels/websocket"
+	"bastionzero.com/bctl/v1/bzerolib/logger"
+	"bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	bzshell "bastionzero.com/bctl/v1/bzerolib/plugin/shell"
+	"github.com/google/uuid"
+	"gopkg.in/tomb.v2"
+)
+
+const (
+	// websocket connection parameters for all datachannels created by tcp server
+	autoReconnect = false
+	getChallenge  = false
+)
+
+type ShellServer struct {
+	logger    *logger.Logger
+	websocket *websocket.Websocket
+	tmb       tomb.Tomb
+
+	// Handler to select message types
+	targetSelectHandler func(msg am.AgentMessage) (string, error)
+
+	// Shell specific vars
+	targetUser string
+
+	// fields for new datachannels
+	params              map[string]string
+	headers             map[string]string
+	serviceUrl          string
+	refreshTokenCommand string
+	configPath          string
+	agentPubKey         string
+}
+
+func StartShellServer(
+	logger *logger.Logger,
+	targetUser string,
+	refreshTokenCommand string,
+	configPath string,
+	serviceUrl string,
+	params map[string]string,
+	headers map[string]string,
+	agentPubKey string,
+	targetSelectHandler func(msg am.AgentMessage) (string, error)) error {
+
+	shellServer := &ShellServer{
+		logger:              logger,
+		serviceUrl:          serviceUrl,
+		params:              params,
+		headers:             headers,
+		targetSelectHandler: targetSelectHandler,
+		configPath:          configPath,
+		refreshTokenCommand: refreshTokenCommand,
+		targetUser:          targetUser,
+		agentPubKey:         agentPubKey,
+	}
+
+	// Create a new websocket
+	if err := shellServer.newWebsocket(uuid.New().String()); err != nil {
+		shellServer.logger.Error(err)
+		return err
+	}
+
+	// create our new datachannel in its own go routine so that we can accept other tcp connections
+	go func() {
+		if _, err := shellServer.newDataChannel(string(shell.UnixShell), shellServer.websocket); err == nil {
+		} else {
+			logger.Errorf("error starting datachannel: %s", err)
+		}
+	}()
+
+	return nil
+}
+
+// for creating new websockets
+func (ss *ShellServer) newWebsocket(wsId string) error {
+	subLogger := ss.logger.GetWebsocketLogger(wsId)
+	if wsClient, err := websocket.New(subLogger, ss.serviceUrl, ss.params, ss.headers, ss.targetSelectHandler, autoReconnect, getChallenge, ss.refreshTokenCommand, websocket.Shell); err != nil {
+		return err
+	} else {
+		ss.websocket = wsClient
+		return nil
+	}
+}
+
+// for creating new datachannels
+func (ss *ShellServer) newDataChannel(action string, websocket *websocket.Websocket) (*datachannel.DataChannel, error) {
+	// every datachannel gets a uuid to distinguish it so a single websockets can map to multiple datachannels
+	dcId := uuid.New().String()
+	subLogger := ss.logger.GetDatachannelLogger(dcId)
+
+	ss.logger.Infof("Creating new datachannel id: %s", dcId)
+
+	// Build the action payload to send in the syn message when opening the data channel
+	actionParams := bzshell.ShellOpenMessage{
+		TargetUser: ss.targetUser,
+	}
+	actionParamsMarshalled, _ := json.Marshal(actionParams)
+
+	action = string(bzshell.ShellOpen)
+	if dc, dcTmb, err := datachannel.New(subLogger, dcId, &ss.tmb, websocket, ss.refreshTokenCommand, ss.configPath, action, actionParamsMarshalled, ss.agentPubKey); err != nil {
+		ss.logger.Error(err)
+		return nil, err
+	} else {
+
+		// create a function to listen to the datachannel dying and then exit the shell daemon process
+		go func() {
+			for {
+				select {
+				case <-ss.tmb.Dying():
+					dc.Close(errors.New("shell server exiting...closing data channel"))
+					return
+				case <-dcTmb.Dying():
+					// Wait until everything is dead and any close processes are sent before killing the datachannel
+					dcTmb.Wait()
+
+					// notify agent to close the datachannel
+					ss.logger.Info("Sending DataChannel Close")
+					cdMessage := am.AgentMessage{
+						ChannelId:   dcId,
+						MessageType: string(am.CloseDataChannel),
+					}
+					ss.websocket.Send(cdMessage)
+
+					errorCode := 1
+					os.Exit(errorCode)
+				}
+			}
+		}()
+		return dc, nil
+	}
+}

--- a/bctl/go.mod
+++ b/bctl/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/build v0.0.0-20211108163316-3ce30f35b9aa
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3

--- a/bzerolib/controllers/connectionnodecontroller/connectionnodecontroller.go
+++ b/bzerolib/controllers/connectionnodecontroller/connectionnodecontroller.go
@@ -90,6 +90,13 @@ func (c *ConnectionNodeController) CreateWebConnection(targetId string) (Connect
 	return c.createConnection(createWebConnectionRequest, "web")
 }
 
+func (c *ConnectionNodeController) CreateShellConnection(connectionId string) (ConnectionDetailsResponse, error) {
+	// Currently shell connections are still created by the zli before starting
+	// the daemon. So here we just need to directly query for the connection
+	// auth details
+	return c.createCnConnection(connectionId)
+}
+
 func (c *ConnectionNodeController) createConnection(request interface{}, connectionType string) (ConnectionDetailsResponse, error) {
 	// Build the endpoint we want to hit
 	endpoint := ""

--- a/bzerolib/plugin/shell/shell.go
+++ b/bzerolib/plugin/shell/shell.go
@@ -13,6 +13,16 @@
 
 package shell
 
+type ShellAction string
+
+const (
+	UnixShell ShellAction = "unixshell"
+)
+
+type ShellActionParams struct {
+	TargetUser string `json:"targetUser"`
+}
+
 type ShellOpenMessage struct {
 	TargetUser string `json:"targetUser"`
 }
@@ -30,12 +40,12 @@ type ShellResizeMessage struct {
 
 type ShellReplayMessage struct{}
 
-type ShellAction string
+type ShellSubAction string
 
 const (
-	ShellOpen    ShellAction = "open"
-	ShellClose   ShellAction = "close"
-	ShellResize  ShellAction = "resize"
-	ShellInput   ShellAction = "input"
-	ShelllReplay ShellAction = "replay"
+	ShellOpen    ShellSubAction = "shell/open"
+	ShellClose   ShellSubAction = "shell/close"
+	ShellResize  ShellSubAction = "shell/resize"
+	ShellInput   ShellSubAction = "shell/input"
+	ShelllReplay ShellSubAction = "shell/replay"
 )

--- a/bzerolib/testutils/testutils.go
+++ b/bzerolib/testutils/testutils.go
@@ -9,7 +9,7 @@ import (
 )
 
 func MockLogger() *logger.Logger {
-	logger, err := logger.New(logger.DefaultLoggerConfig(logger.Debug.String()), "/dev/null")
+	logger, err := logger.New(logger.DefaultLoggerConfig(logger.Debug.String()), "/dev/null", false)
 	if err == nil {
 		return logger
 	}


### PR DESCRIPTION
## Description of the change

This adds a new shell plugin to the daemon which implements the existing shell websocket keysplitting protocol as shell-connection-service did in typescript. It functions differently then the other plugins in that it is not meant to be run as a long-living background process. Instead when started with the shell plugin the daemon is expected to inherit the zli process' std in/out. The daemon then handles reading/writing directly to std in/out. When the shell daemon exits (either due to protocol error or from a shell/quit stream message that indicates the pty was killed on the target) the process is directly killed using os.exit(). Meanwhile the zli just needs to spawn the daemon as a subprocess, let it do all the work, and wait for it to exit before exiting the zli command.

# Testing

## Dependencies

backend: In order to test the shell plugin you need to be on the latest `feat/shell` branch of webshell-backend https://github.com/bastionzero/webshell-backend/pull/1012 (which includes running a db migration).   

ZLI: pending pr

You should be able to connect directly to a bzero target provided you have a target access policy that allows access to that target or environment. If you are testing against a development agent spawned via `bzero-dev` you will need to make sure to connect as target user: `ec2-user`.  

Then Simply run the `zli connect` command. e.g
```
zli-linux connect ec2-user@sebby-bzero-agent
```

## TODO

- [ ] Attach support. There are some complications with this im still working through because it is dependent on a signal control message sent from bastion directly which we dont currently handle in websocket.go.  

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1692

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: