### PR TITLE
Dont log error if tmb is dying

### DIFF
--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -229,7 +229,7 @@ func (d *DataChannel) startPlugin(pluginName bzplugin.PluginName, action string,
 			case <-d.tmb.Dying():
 				return
 			case streamMessage := <-streamOutputChan:
-				d.logger.Infof("Sending %s/%s/%v stream message", streamMessage.Action, streamMessage.Type, streamMessage.More)
+				d.logger.Infof("Sending %s - %s - %v stream message", streamMessage.Action, streamMessage.Type, streamMessage.More)
 				d.send(am.Stream, streamMessage)
 			}
 		}

--- a/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
@@ -202,8 +202,6 @@ func (d *DefaultShell) writePump() {
 	// Wait for all input commands to run.
 	time.Sleep(time.Second)
 
-	d.logger.Infof("HERE: %s", d.terminal.Closed())
-
 	for {
 		if stdoutBytesLen, err := reader.Read(stdoutBytes); err != nil {
 			if !d.terminal.Closed() {

--- a/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
@@ -214,8 +214,10 @@ func (d *DefaultShell) writePump() {
 
 	for {
 		if stdoutBytesLen, err := reader.Read(stdoutBytes); err != nil {
+			if d.tmb.Alive() {
+				d.logger.Errorf("error reading from stdout: %s", err)
+			}
 			d.sendStreamMessage(smsg.Stop, stdoutBytes[:stdoutBytesLen])
-			d.logger.Errorf("error reading from stdout: %s", err)
 			return
 		} else {
 			d.stdoutbuff.Write(stdoutBytes[:stdoutBytesLen])

--- a/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
@@ -127,6 +127,17 @@ func (d *DefaultShell) Receive(action string, actionPayload []byte) (string, []b
 			return action, replayBytes, nil
 		}
 
+		// outbuff := make([]byte, ShellStdOutBuffCapacity)
+		// d.stdoutbuffMutex.Lock()
+		// defer d.stdoutbuffMutex.Unlock()
+
+		// // does this need a timeout?
+		// if n, err := d.stdoutbuff.Read(outbuff); err != nil {
+		// 	return action, []byte{}, fmt.Errorf("failed to read from stdout buff for shell replay %s", err)
+		// } else {
+		// 	return action, outbuff[0:n], nil
+		// }
+
 	default:
 		return action, []byte{}, fmt.Errorf("unrecognized shell action received: %s", action)
 	}

--- a/bctl/agent/plugin/shell/actions/defaultshell/pseudoterminal/pseudoterminal.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/pseudoterminal/pseudoterminal.go
@@ -154,9 +154,11 @@ func (p *PseudoTerminal) Done() <-chan struct{} {
 }
 
 func (p *PseudoTerminal) Closed() bool {
-	if p.command != nil {
+	if p.command.ProcessState != nil {
 		return p.command.ProcessState.Exited()
 	} else {
+		// If we have not defined processState,
+		// that means that program has not started yet
 		return false
 	}
 }

--- a/bctl/agent/plugin/shell/actions/defaultshell/pseudoterminal/pseudoterminal.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/pseudoterminal/pseudoterminal.go
@@ -140,7 +140,7 @@ func (p *PseudoTerminal) Done() <-chan struct{} {
 		if p.command == nil {
 			return
 		} else if err := p.command.Wait(); err != nil {
-			// d.logger.Errorf("pty command exited with err: %s", err)
+			p.logger.Errorf("pty command exited with err: %s", err)
 			if exitError, ok := err.(*exec.ExitError); ok {
 				exitCode := exitError.ExitCode()
 				p.logger.Errorf("pty cmd exited with non-zero exit code %d err: %s", exitCode, err)
@@ -151,6 +151,14 @@ func (p *PseudoTerminal) Done() <-chan struct{} {
 	}()
 
 	return doneChan
+}
+
+func (p *PseudoTerminal) Closed() bool {
+	if p.command != nil {
+		return p.command.ProcessState.Exited()
+	} else {
+		return false
+	}
 }
 
 func (p *PseudoTerminal) Kill() {


### PR DESCRIPTION
## Description of the change

Noticed an error is being logged when we type `exit`:
```
6:48PM ERR error reading from stdout: read /dev/ptmx: file already closed action=shell/default agentVersion=$AGENT_VERSION controlchannel=b0b15c0b-d9d8-4aff-9dfe-d86ae1aa9683 datachannel=ed8b3756-db37-4d38-97ea-1ab14ffe8aa6 plugin=shell
```

But this is not accurate, what is happening is the tty shell is done, since we typed exit. This PR fixes that error being logged by only logging if we are not dying. 

I believe the shell is being killed here: https://github.com/bastionzero/bzero/blob/dont-log-error-if-dying/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go#L97

Which kills the process: (https://github.com/bastionzero/bzero/blob/dont-log-error-if-dying/bctl/agent/plugin/shell/actions/defaultshell/pseudoterminal/pseudoterminal.go#L160-L166)

```
func (p *PseudoTerminal) Kill() {
	if p.command != nil && p.command.Process != nil {
		if err := p.command.Process.Kill(); err != nil {
			p.logger.Errorf("failed to close command process: %s", err)
		}
	}
}
```

When we type exit. So that is the origin of this issue. 

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: