### PR TITLE
Handle pty exit

### DIFF
--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -229,7 +229,7 @@ func (d *DataChannel) startPlugin(pluginName bzplugin.PluginName, action string,
 			case <-d.tmb.Dying():
 				return
 			case streamMessage := <-streamOutputChan:
-				d.logger.Infof("Sending %s/%s/%v stream message", streamMessage.Action, streamMessage.Type, streamMessage.More)
+				d.logger.Infof("Sending %s - %s - %v stream message", streamMessage.Action, streamMessage.Type, streamMessage.More)
 				d.send(am.Stream, streamMessage)
 			}
 		}


### PR DESCRIPTION
## Description of the change

+ Makes sure the pseudoterminal class has only a single done channel that it returns in the `Done()` method
+ Handle the done event in defaultshell.writePump by sending a stream stop message and returning (this happens before reading from stdout without logging an error)


## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: