### PR TITLE
Schema version handshake

### DIFF
--- a/bzerolib/keysplitting/message/dataackpayload.go
+++ b/bzerolib/keysplitting/message/dataackpayload.go
@@ -18,12 +18,12 @@ type DataAckPayload struct {
 	ActionResponsePayload []byte `json:"actionResponsePayload"`
 }
 
-func (d DataAckPayload) BuildResponsePayload(action string, actionPayload []byte, bzCertHash string) (DataPayload, error) {
+func (d DataAckPayload) BuildResponsePayload(action string, actionPayload []byte, bzCertHash string, schemaVersion string) (DataPayload, error) {
 	hashBytes, _ := util.HashPayload(d)
 	hash := base64.StdEncoding.EncodeToString(hashBytes)
 
 	return DataPayload{
-		SchemaVersion: SchemaVersion,
+		SchemaVersion: schemaVersion,
 		Type:          string(Data),
 		Action:        action,
 		TargetId:      d.TargetPublicKey, //TODO: Make this come from storage

--- a/bzerolib/keysplitting/message/datapayload.go
+++ b/bzerolib/keysplitting/message/datapayload.go
@@ -19,12 +19,12 @@ type DataPayload struct {
 	ActionPayload []byte `json:"actionPayload"`
 }
 
-func (d DataPayload) BuildResponsePayload(actionPayload []byte, pubKey string) (DataAckPayload, error) {
+func (d DataPayload) BuildResponsePayload(actionPayload []byte, pubKey string, schemaVersion string) (DataAckPayload, error) {
 	hashBytes, _ := util.HashPayload(d)
 	hash := base64.StdEncoding.EncodeToString(hashBytes)
 
 	return DataAckPayload{
-		SchemaVersion:         SchemaVersion,
+		SchemaVersion:         schemaVersion,
 		Type:                  string(DataAck),
 		Action:                d.Action,
 		TargetPublicKey:       pubKey,

--- a/bzerolib/keysplitting/message/keysplittingmessage.go
+++ b/bzerolib/keysplitting/message/keysplittingmessage.go
@@ -80,7 +80,7 @@ func (k *KeysplittingMessage) BuildUnsignedData(action string, actionPayload []b
 			}, nil
 		}
 	case DataAckPayload:
-		if dataPayload, err := msg.BuildResponsePayload(action, actionPayload, bzcertHash); err != nil {
+		if dataPayload, err := msg.BuildResponsePayload(action, actionPayload, bzcertHash, schemaVersion); err != nil {
 			return KeysplittingMessage{}, err
 		} else {
 			return KeysplittingMessage{

--- a/bzerolib/keysplitting/message/keysplittingmessage.go
+++ b/bzerolib/keysplitting/message/keysplittingmessage.go
@@ -38,9 +38,9 @@ func (k *KeysplittingMessage) Hash() string {
 	}
 }
 
-func (k *KeysplittingMessage) BuildUnsignedSynAck(payload []byte, pubKey string, nonce string) (KeysplittingMessage, error) {
+func (k *KeysplittingMessage) BuildUnsignedSynAck(payload []byte, pubKey string, nonce string, schemaVersion string) (KeysplittingMessage, error) {
 	if msg, ok := k.KeysplittingPayload.(SynPayload); ok {
-		if synAckPayload, err := msg.BuildResponsePayload(payload, pubKey, nonce); err != nil {
+		if synAckPayload, err := msg.BuildResponsePayload(payload, pubKey, nonce, schemaVersion); err != nil {
 			return KeysplittingMessage{}, err
 		} else {
 			return KeysplittingMessage{
@@ -53,9 +53,9 @@ func (k *KeysplittingMessage) BuildUnsignedSynAck(payload []byte, pubKey string,
 	}
 }
 
-func (k *KeysplittingMessage) BuildUnsignedDataAck(payload []byte, pubKey string) (KeysplittingMessage, error) {
+func (k *KeysplittingMessage) BuildUnsignedDataAck(payload []byte, pubKey string, schemaVersion string) (KeysplittingMessage, error) {
 	if msg, ok := k.KeysplittingPayload.(DataPayload); ok {
-		if dataAckPayload, err := msg.BuildResponsePayload(payload, pubKey); err != nil {
+		if dataAckPayload, err := msg.BuildResponsePayload(payload, pubKey, schemaVersion); err != nil {
 			return KeysplittingMessage{}, err
 		} else {
 			return KeysplittingMessage{
@@ -68,10 +68,10 @@ func (k *KeysplittingMessage) BuildUnsignedDataAck(payload []byte, pubKey string
 	}
 }
 
-func (k *KeysplittingMessage) BuildUnsignedData(action string, actionPayload []byte, bzcertHash string) (KeysplittingMessage, error) {
+func (k *KeysplittingMessage) BuildUnsignedData(action string, actionPayload []byte, bzcertHash string, schemaVersion string) (KeysplittingMessage, error) {
 	switch msg := k.KeysplittingPayload.(type) {
 	case SynAckPayload:
-		if dataPayload, err := msg.BuildResponsePayload(action, actionPayload, bzcertHash); err != nil {
+		if dataPayload, err := msg.BuildResponsePayload(action, actionPayload, bzcertHash, schemaVersion); err != nil {
 			return KeysplittingMessage{}, err
 		} else {
 			return KeysplittingMessage{

--- a/bzerolib/keysplitting/message/synackpayload.go
+++ b/bzerolib/keysplitting/message/synackpayload.go
@@ -21,12 +21,12 @@ type SynAckPayload struct {
 	HPointer        string `json:"hPointer"`
 }
 
-func (s SynAckPayload) BuildResponsePayload(action string, actionPayload []byte, bzCertHash string) (DataPayload, error) {
+func (s SynAckPayload) BuildResponsePayload(action string, actionPayload []byte, bzCertHash string, schemaVersion string) (DataPayload, error) {
 	hashBytes, _ := util.HashPayload(s)
 	hash := base64.StdEncoding.EncodeToString(hashBytes)
 
 	return DataPayload{
-		SchemaVersion: SchemaVersion,
+		SchemaVersion: schemaVersion,
 		Type:          string(Data),
 		Action:        action,
 		TargetId:      s.TargetPublicKey, // TODO: Make this come from storage

--- a/bzerolib/keysplitting/message/synpayload.go
+++ b/bzerolib/keysplitting/message/synpayload.go
@@ -24,12 +24,12 @@ type SynPayload struct {
 	BZCert   bzcrt.BZCert `json:"bZCert"`
 }
 
-func (s SynPayload) BuildResponsePayload(actionPayload []byte, pubKey string, nonce string) (SynAckPayload, error) {
+func (s SynPayload) BuildResponsePayload(actionPayload []byte, pubKey string, nonce string, schemaVersion string) (SynAckPayload, error) {
 	hashBytes, _ := util.HashPayload(s)
 	hash := base64.StdEncoding.EncodeToString(hashBytes)
 
 	return SynAckPayload{
-		SchemaVersion:         SchemaVersion,
+		SchemaVersion:         schemaVersion,
 		Type:                  string(SynAck),
 		Action:                s.Action,
 		ActionResponsePayload: actionPayload,


### PR DESCRIPTION
## Description of the change

When determining the schemaVersion to use the agent will select whichever schemaVersion is lower between the agent/daemon and set that in the synack. The daemon will then use that schema version for all data messages. This fixes a backwards compatibility bug where command extraction would fail when new daemon's (2.0) were connecting to old agents because the daemon is "dirtying" the keysplitting message payloads.

## Testing

Describe how to test this PR....

**backend branch:** fix/extra-quotes-in-payload
**zli branch:** 

#### Ready to run system tests?

- [ ] Yes

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-XXX

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [ ] No

If yes, please explain: