### PR TITLE
[Agent] Fix websocket connections not properly closed properly

### DIFF
--- a/bctl/agent/datachannel/datachannel.go
+++ b/bctl/agent/datachannel/datachannel.go
@@ -110,6 +110,7 @@ func New(
 				datachannel.plugin.Kill()
 				return errors.New("agent was orphaned too young and can't be batman :'(")
 			case <-datachannel.tmb.Dying():
+				logger.Infof("datachannel is dying...killing plugin")
 				datachannel.plugin.Kill()
 				return nil
 			case <-datachannel.plugin.Done():

--- a/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
+++ b/bctl/agent/plugin/shell/actions/defaultshell/defaultshell.go
@@ -85,6 +85,8 @@ func (d *DefaultShell) Kill() {
 	if d.terminal != nil {
 		d.terminal.Kill()
 		d.terminal = nil
+
+		// Wait for done channel to be closed by writePump
 		<-d.doneChan
 	}
 }


### PR DESCRIPTION
## Description of the change

This fixes a bug where shell connections were hanging on the daemon side if a shell connection was closed via the control channel (when a connection is closed directly via api e.g `zli close` or closed by bastion zero backend e.g revocation).  Although the underlying issue seems to have been more general issue that we were not properly closing websocket connections on the agent side when receiving messages in control channel to close the websocket. Previously when receiving a websocket close message in the control channel the websocket tmb would be killed but it would never finish waiting [here](https://github.com/bastionzero/bzero/blob/612225afbac3c515ebb23844c73f30bce0e66ba0/bzerolib/channels/websocket/websocket.go#L213) for its tracked receive routine to complete and would be leaked. This was causing the agent to not gracefully shutdown when restarted and take a very long time to restart:

``` 
Stopping bzero-agent.service...
bzero-agent.service stop-final-sigterm timed out. Killing.
```

Because the agent was never disconnecting from the websocket we were never trigger the `OnDisconnectedAsync` methiod in the backend that sends a message to close all daemon websockets when an agent websocket disconnects [here](https://github.com/bastionzero/webshell-backend/blob/7dc9852e23c6a40fb36e7b979419a020f1f16da7/ConnectionNode/Agent/AgentDataChannelWebsocketHub/AgentDataChannelWebsocketHub.cs#L181-L192). This would lead to the daemon shell connections just being hung.

This also fixes a bug in defaultshell where we would not kill the pty command process. (I think this process was previously never being closed). This also adds extra insurance on top of just closing the pty fd that the default shell plugin will be killed properly as the the pseudoterminal done channel waits for the pty command to complete.

## Testing

1. Create a shell connection to a bzero target
2. Kill the connection by  any means except typing exit/ctrl+d
    - Close the connection via api or `zli close <connection-id>
    - Revoke all your user connections from the webapp
    - Close the connection in the cli-space from the webapp (how this bug was originally reported)
  
 After you close the connection the daemon should no longer hang but should also exit:
 
```
➜  zli git:(develop) ✗ ./bin/zli-linux connect ec2-user@sebby-bzero-agent 
Logged in as: sebby@commonwealthcrypto.com, bzero-id:7f59e879-5f58-4d3b-bd23-44381980080d, session-id:e59702cf-9437-4eab-88d7-0524b07be156
[ec2-user@ip-172-31-17-236 ~]$ error: closing message received; websocket closed%   
```

# TODO

- [ ] Better error message on the daemon side when websocket is closed.

**backend branch:** 
**zli branch:** 

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes: Fixes bug where shell connections were hanging when the connection was closed via an external mechanism

## Related JIRA tickets

Relates to JIRA: CWC-1833

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: