### PR TITLE
Add support for known_hosts

### DIFF
--- a/bctl/agent/plugin/ssh/actions/opaquessh/opaquessh.go
+++ b/bctl/agent/plugin/ssh/actions/opaquessh/opaquessh.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/tomb.v2"
 
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/ssh/authorizedkeys"
+	"bastionzero.com/bctl/v1/bzerolib/bzio"
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	bzssh "bastionzero.com/bctl/v1/bzerolib/plugin/ssh"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
@@ -19,6 +20,7 @@ import (
 const (
 	chunkSize     = 64 * 1024
 	writeDeadline = 5 * time.Second
+	rsaKeyPath    = "/etc/ssh/ssh_host_rsa_key.pub"
 )
 
 type OpaqueSsh struct {
@@ -34,9 +36,11 @@ type OpaqueSsh struct {
 
 	remoteConnection *net.TCPConn
 	authorizedKeys   authorizedkeys.IAuthorizedKeys
+
+	fileIo bzio.BzFileIo
 }
 
-func New(logger *logger.Logger, doneChan chan struct{}, ch chan smsg.StreamMessage, conn *net.TCPConn, authKeys authorizedkeys.IAuthorizedKeys) *OpaqueSsh {
+func New(logger *logger.Logger, doneChan chan struct{}, ch chan smsg.StreamMessage, conn *net.TCPConn, authKeys authorizedkeys.IAuthorizedKeys, fileIo bzio.BzFileIo) *OpaqueSsh {
 
 	return &OpaqueSsh{
 		logger:           logger,
@@ -44,6 +48,7 @@ func New(logger *logger.Logger, doneChan chan struct{}, ch chan smsg.StreamMessa
 		streamOutputChan: ch,
 		remoteConnection: conn,
 		authorizedKeys:   authKeys,
+		fileIo:           fileIo,
 	}
 }
 
@@ -107,11 +112,18 @@ func (s *OpaqueSsh) start(openRequest bzssh.SshOpenMessage, action string) ([]by
 	s.streamMessageVersion = openRequest.StreamMessageVersion
 	s.logger.Debugf("Setting stream message version: %s", s.streamMessageVersion)
 
+	// send an RSA key to the daemon if we can find it
+	if rsaKey, err := s.fileIo.ReadFile(rsaKeyPath); err != nil {
+		s.logger.Errorf("unable to read key file at %s: %s", rsaKeyPath, err)
+	} else {
+		s.sendStreamMessage(0, smsg.Data, false, rsaKey)
+	}
+
 	// Setup a go routine to listen for messages coming from this local connection and send to daemon
 	s.tmb.Go(func() error {
 		defer close(s.doneChan)
 
-		sequenceNumber := 0
+		sequenceNumber := 1
 		buff := make([]byte, chunkSize)
 
 		for {

--- a/bctl/agent/plugin/ssh/actions/transparentssh/transparentssh.go
+++ b/bctl/agent/plugin/ssh/actions/transparentssh/transparentssh.go
@@ -52,8 +52,10 @@ func (t *TransparentSsh) Kill() {
 	if t.conn != nil {
 		t.conn.Close()
 	}
-	t.tmb.Kill(nil)
-	t.tmb.Wait()
+	if t.tmb.Alive() {
+		t.tmb.Kill(nil)
+		t.tmb.Wait()
+	}
 }
 
 func (t *TransparentSsh) Receive(action string, actionPayload []byte) ([]byte, error) {
@@ -159,7 +161,7 @@ func (t *TransparentSsh) start(openRequest bzssh.SshOpenMessage, action string) 
 		for {
 			select {
 			case <-t.tmb.Dying():
-				t.logger.Errorf("tomb was killed. Stopping...")
+				t.logger.Infof("tomb was killed. Going to stop writing to stdin")
 				return nil
 			case d := <-t.stdInChan:
 				t.logger.Debugf("Writing %d bytes to stdin", len(d))

--- a/bctl/agent/plugin/ssh/ssh.go
+++ b/bctl/agent/plugin/ssh/ssh.go
@@ -12,6 +12,7 @@ import (
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/ssh/actions/opaquessh"
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/ssh/actions/transparentssh"
 	"bastionzero.com/bctl/v1/bctl/agent/plugin/ssh/authorizedkeys"
+	"bastionzero.com/bctl/v1/bzerolib/bzio"
 	"bastionzero.com/bctl/v1/bzerolib/logger"
 	bzssh "bastionzero.com/bctl/v1/bzerolib/plugin/ssh"
 	smsg "bastionzero.com/bctl/v1/bzerolib/stream/message"
@@ -96,6 +97,7 @@ func New(logger *logger.Logger, ch chan smsg.StreamMessage, action string, paylo
 					plugin.streamOutputChan,
 					remoteConnection,
 					authKeys,
+					bzio.OsFileIo{},
 				)
 
 			case bzssh.TransparentSsh:

--- a/bctl/daemon/daemon.go
+++ b/bctl/daemon/daemon.go
@@ -48,8 +48,10 @@ var (
 	dataChannelId string
 
 	// SSH specific arguments
-	identityFile string
-	sshAction    string
+	identityFile   string
+	knownHostsFile string
+	sshAction      string
+	hostNames      string // comma-separated list
 )
 
 const (
@@ -182,6 +184,8 @@ func startSshServer(logger *bzlogger.Logger, headers map[string]string, params m
 		agentPubKey,
 		targetSelectHandler,
 		identityFile,
+		knownHostsFile,
+		strings.Split(hostNames, ","),
 		remoteHost,
 		remotePort,
 		localPort,
@@ -314,7 +318,9 @@ func parseFlags() error {
 
 	// SSH plugin variables
 	flag.StringVar(&identityFile, "identityFile", "", "Path to an SSH IdentityFile")
+	flag.StringVar(&knownHostsFile, "knownHostsFile", "", "Path to bz-known_hosts")
 	flag.StringVar(&sshAction, "sshAction", "", "One of ['opaque', 'transparent']")
+	flag.StringVar(&hostNames, "hostNames", "", "Comma-separated list of hostNames to use for this target")
 
 	flag.Parse()
 
@@ -340,7 +346,7 @@ func parseFlags() error {
 	case bzplugin.Shell:
 		requiredFlags = append(requiredFlags, "targetUser", "connectionId")
 	case bzplugin.Ssh:
-		requiredFlags = append(requiredFlags, "targetUser", "targetId", "remoteHost", "remotePort", "sshAction")
+		requiredFlags = append(requiredFlags, "targetUser", "targetId", "remoteHost", "identityFile", "knownHostsFile", "hostNames", "remotePort", "sshAction")
 	default:
 		return fmt.Errorf("unhandled plugin passed: %s", plugin)
 	}

--- a/bctl/daemon/daemon.go
+++ b/bctl/daemon/daemon.go
@@ -318,7 +318,7 @@ func parseFlags() error {
 
 	// SSH plugin variables
 	flag.StringVar(&identityFile, "identityFile", "", "Path to an SSH IdentityFile")
-	flag.StringVar(&knownHostsFile, "knownHostsFile", "", "Path to bz-known_hosts")
+	flag.StringVar(&knownHostsFile, "knownHostsFile", "", "Path to bastionzero-known_hosts")
 	flag.StringVar(&sshAction, "sshAction", "", "One of ['opaque', 'transparent']")
 	flag.StringVar(&hostNames, "hostNames", "", "Comma-separated list of hostNames to use for this target")
 

--- a/bctl/daemon/plugin/ssh/actions/opaquessh/opaquessh_test.go
+++ b/bctl/daemon/plugin/ssh/actions/opaquessh/opaquessh_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Daemon OpaqueSsh action", func() {
 			// can't check the public key's contents but we can make sure it's there
 			Expect(len(openPayload.PublicKey)).Should(BeNumerically(">", 0))
 
-			By("writing the remote host key to bz-known_hosts")
+			By("writing the remote host key to bastionzero-known_hosts")
 			s.ReceiveStream(smsg.StreamMessage{
 				Type:    smsg.Data,
 				Content: base64.StdEncoding.EncodeToString([]byte(tests.DemoPub)),

--- a/bctl/daemon/plugin/ssh/actions/transparentssh/transparentssh.go
+++ b/bctl/daemon/plugin/ssh/actions/transparentssh/transparentssh.go
@@ -92,7 +92,6 @@ func (t *TransparentSsh) Start() error {
 	if err != nil {
 		return fmt.Errorf("failed to set up ssh keypair: %s", err)
 	} else {
-		t.logger.Infof("wait do I still write here?")
 		if err := t.knownHosts.AddHostKeyPrivate(privateKey); err != nil {
 			return fmt.Errorf("failed to update known_hosts file: %s", err)
 		}

--- a/bctl/daemon/plugin/ssh/ssh.go
+++ b/bctl/daemon/plugin/ssh/ssh.go
@@ -54,7 +54,6 @@ func (s *SshDaemonPlugin) StartAction(actionName string) error {
 	actLogger := s.logger.GetActionLogger(actionName)
 	switch actionName {
 	case string(bzssh.OpaqueSsh):
-		// FIXME: add args
 		s.action = opaquessh.New(actLogger, s.outboxQueue, s.doneChan, s.stdIo, s.identityFile, s.knownHosts)
 	case string(bzssh.TransparentSsh):
 		// listen for a connection from the ZLI

--- a/bctl/daemon/servers/sshserver/sshserver.go
+++ b/bctl/daemon/servers/sshserver/sshserver.go
@@ -127,7 +127,6 @@ func (s *SshServer) newDataChannel(action string, websocket *websocket.Websocket
 
 	idFile := bzssh.NewIdentityFile(s.identityFile, fileIo)
 	khFile := bzssh.NewKnownHosts(s.knownHostsFile, s.hostNames, fileIo)
-	s.logger.Infof("known_hosts at %s", s.knownHostsFile)
 
 	plugin := ssh.New(pluginLogger, s.localPort, idFile, khFile, bzio.StdIo{})
 	if err := plugin.StartAction(action); err != nil {

--- a/bctl/daemon/servers/sshserver/sshserver.go
+++ b/bctl/daemon/servers/sshserver/sshserver.go
@@ -34,11 +34,14 @@ type SshServer struct {
 	// Handler to select message types
 	targetSelectHandler func(msg am.AgentMessage) (string, error)
 
-	remoteHost   string
-	remotePort   int
-	localPort    string
-	targetUser   string
-	identityFile string
+	remoteHost string
+	remotePort int
+	localPort  string
+	targetUser string
+
+	identityFile   string
+	knownHostsFile string
+	hostNames      []string
 
 	// fields for new datachannels
 	params      map[string]string
@@ -59,6 +62,8 @@ func StartSshServer(
 	agentPubKey string,
 	targetSelectHandler func(msg am.AgentMessage) (string, error),
 	identityFile string,
+	knownHostsFile string,
+	hostNames []string,
 	remoteHost string,
 	remotePort int,
 	localPort string,
@@ -75,6 +80,8 @@ func StartSshServer(
 		cert:                cert,
 		agentPubKey:         agentPubKey,
 		identityFile:        identityFile,
+		knownHostsFile:      knownHostsFile,
+		hostNames:           hostNames,
 		remoteHost:          remoteHost,
 		remotePort:          remotePort,
 		localPort:           localPort,
@@ -89,6 +96,7 @@ func StartSshServer(
 	// create our new datachannel
 	if err := server.newDataChannel(action, server.websocket); err != nil {
 		logger.Errorf("error starting datachannel: %s", err)
+		return err
 	}
 
 	return nil
@@ -115,7 +123,13 @@ func (s *SshServer) newDataChannel(action string, websocket *websocket.Websocket
 
 	pluginLogger := subLogger.GetPluginLogger(bzplugin.Ssh)
 
-	plugin := ssh.New(pluginLogger, s.identityFile, s.localPort, bzio.OsFileIo{}, bzio.StdIo{})
+	fileIo := bzio.OsFileIo{}
+
+	idFile := bzssh.NewIdentityFile(s.identityFile, fileIo)
+	khFile := bzssh.NewKnownHosts(s.knownHostsFile, s.hostNames, fileIo)
+	s.logger.Infof("known_hosts at %s", s.knownHostsFile)
+
+	plugin := ssh.New(pluginLogger, s.localPort, idFile, khFile, bzio.StdIo{})
 	if err := plugin.StartAction(action); err != nil {
 		return fmt.Errorf("failed to start action: %s", err)
 	}

--- a/bzerolib/plugin/ssh/identityfile.go
+++ b/bzerolib/plugin/ssh/identityfile.go
@@ -1,0 +1,30 @@
+package ssh
+
+import (
+	"bastionzero.com/bctl/v1/bzerolib/bzio"
+)
+
+type IIdentityFile interface {
+	SetKey(privateKey []byte) error
+	GetKey() ([]byte, error)
+}
+
+type IdentityFile struct {
+	filePath string
+	fileIo   bzio.BzFileIo
+}
+
+func NewIdentityFile(filePath string, fileIo bzio.BzFileIo) *IdentityFile {
+	return &IdentityFile{
+		filePath: filePath,
+		fileIo:   fileIo,
+	}
+}
+
+func (f *IdentityFile) SetKey(privateKey []byte) error {
+	return f.fileIo.WriteFile(f.filePath, privateKey, 0600)
+}
+
+func (f *IdentityFile) GetKey() ([]byte, error) {
+	return f.fileIo.ReadFile(f.filePath)
+}

--- a/bzerolib/plugin/ssh/knownhosts.go
+++ b/bzerolib/plugin/ssh/knownhosts.go
@@ -29,7 +29,6 @@ func NewKnownHosts(filePath string, hosts []string, fileIo bzio.BzFileIo) *Known
 }
 
 func (k *KnownHosts) AddHostKeyPrivate(privateKey []byte) error {
-
 	if publicKey, err := ReadPublicKeyRsa(privateKey); err != nil {
 		return fmt.Errorf("failed to decode private key: %s", err)
 	} else if sshKey, err := gossh.NewPublicKey(publicKey); err != nil {
@@ -42,5 +41,4 @@ func (k *KnownHosts) AddHostKeyPrivate(privateKey []byte) error {
 func (k *KnownHosts) AddHostKeyPublic(publicKey gossh.PublicKey) error {
 	keyLine := knownhosts.Line(k.hosts, publicKey)
 	return k.fileIo.WriteFile(k.filePath, []byte(keyLine), 0600)
-
 }

--- a/bzerolib/plugin/ssh/knownhosts.go
+++ b/bzerolib/plugin/ssh/knownhosts.go
@@ -15,7 +15,7 @@ type IKnownHosts interface {
 }
 
 type KnownHosts struct {
-	filePath string // revisit private vs. public
+	filePath string
 	hosts    []string
 	fileIo   bzio.BzFileIo
 }

--- a/bzerolib/plugin/ssh/knownhosts.go
+++ b/bzerolib/plugin/ssh/knownhosts.go
@@ -1,0 +1,46 @@
+package ssh
+
+import (
+	"fmt"
+
+	gossh "golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+
+	"bastionzero.com/bctl/v1/bzerolib/bzio"
+)
+
+type IKnownHosts interface {
+	AddHostKeyPrivate(privateKey []byte) error
+	AddHostKeyPublic(publicKey gossh.PublicKey) error
+}
+
+type KnownHosts struct {
+	filePath string // revisit private vs. public
+	hosts    []string
+	fileIo   bzio.BzFileIo
+}
+
+func NewKnownHosts(filePath string, hosts []string, fileIo bzio.BzFileIo) *KnownHosts {
+	return &KnownHosts{
+		filePath: filePath,
+		hosts:    hosts,
+		fileIo:   fileIo,
+	}
+}
+
+func (k *KnownHosts) AddHostKeyPrivate(privateKey []byte) error {
+
+	if publicKey, err := ReadPublicKeyRsa(privateKey); err != nil {
+		return fmt.Errorf("failed to decode private key: %s", err)
+	} else if sshKey, err := gossh.NewPublicKey(publicKey); err != nil {
+		return fmt.Errorf("failed to process public key: %s", err)
+	} else {
+		return k.AddHostKeyPublic(sshKey)
+	}
+}
+
+func (k *KnownHosts) AddHostKeyPublic(publicKey gossh.PublicKey) error {
+	keyLine := knownhosts.Line(k.hosts, publicKey)
+	return k.fileIo.WriteFile(k.filePath, []byte(keyLine), 0600)
+
+}


### PR DESCRIPTION
## Description of the change

  - **What problem does this solve?** 
    - tl;dr: our implementation of ssh involves a lot of host key changes that we need to hide from the user's ssh process, which is ordinarily very strict about such things (even though checking host keys doesn't really do much)
  - **How does this solve that?**
    - When the user does `zli generate sshConfig`, we now add a special field that instructs ssh to use a custom known_hosts file, bz-known_hosts, instead of the default
    - When the user performs an ssh proxy via ZLI, ZLI passes the daemon a set of hostNames (one of which the user almost certainly used) and the path to bz-known_hosts\
    - The next depends on whether we are tunneling with opaque ssh or copying with transparent ssh:
      - For transparent ssh, the host key is the same as the public key of the identityfile, meaning the daemon generates it if not there or else just reads that file and retrieves the key
      - For opaque ssh, the agent will send the daemon a stream message with the remote machine's host key
    - In either case, the host key is written to bz-known_hosts before the ssh handshake is complete, so the local ssh process checks it and sees that there is a key there. Hooray!
  - **How do I test it?**
    - Once you check out this branch and pull the latest feat/transparent-ssh branch on zli, rsync your agent, and do a fresh `npm run release` / `zli generate sshConfig`, you should be able to connect via transparent or opaque ssh, perform `zli logout` / `zli login`, and never see any warnings about keys being added to known_hosts!!
  - **Any gotchas?**
    - Right now the host key writer completely overwrites the file with each new key. I can't think of a reason this would be a problem and it greatly simplifies the code, but just wanted to flag it
    - The agent only checks one location for a host key, and it only checks for an RSA formatted key while there are probably others in that spot. I think this is fine but if we wanted to, we could have it read any `*_key.pub` file it finds and send it back. **I don't think we need to do this for now but it could be that users of exotic OSs will need it**

## Testing

Describe how to test this PR....

**backend branch:** feat/transparent-ssh
**zli branch:** feat/transparent-ssh

#### Ready to run system tests?

- [x] Yes

## Relevant release note information

Release Notes:

## Related JIRA tickets

Relates to JIRA: CWC-1631

## Have you considered the security impacts?

Does this PR have any security impact?

- [ ] Yes
- [x] No

If yes, please explain: